### PR TITLE
feat: Add feedback section to legend resolves #9

### DIFF
--- a/src/components/Legend.vue
+++ b/src/components/Legend.vue
@@ -113,6 +113,15 @@
         >
         </AppearancePreview>
       </div>
+      <div class="legend-feedback">
+        <h2>Feedback</h2>
+        <ul class="feedback">
+          <li><a href="mailto:jharkey4@gmail.com">Email</a></li>
+          <li><a href="https://www.reddit.com/user/jofwu/">Reddit</a></li>
+          <li><a href="https://www.17thshard.com/forum/profile/18320-jofwu/">17th Shard</a></li>
+          <li><a href="https://github.com/17thshard/reading-order/issues/new">Github</a></li>
+        </ul>
+      </div>
     </div>
   </div>
 </div>
@@ -348,11 +357,16 @@ export default {
     align-items: flex-start;
   }
 
-  &-categories, &-connections, &-appearances {
+  &-categories, &-connections, &-appearances, &-feedback {
     padding-left: 0.5rem;
 
     h2 {
       margin-left: -0.5rem;
+    }
+
+    ul {
+      margin-block: 0;
+      padding-inline-start: 27px;
     }
   }
 


### PR DESCRIPTION
This adds a feedback section to the legend with links to various methods of feedback so the user is able to choose which option they are most comfortable with.