### PR TITLE
Added the connection arrows, with descriptions and links for The Lost Metal

### DIFF
--- a/public/data.json
+++ b/public/data.json
@@ -315,7 +315,12 @@
                                     "target": "sa4",
                                     "type": "minor",
                                     "description": "The communication box used by <a target='_blank' href='https://coppermind.net/wiki/Shallan'>Shallan</a> to communicate with <a target='_blank' href='https://coppermind.net/wiki/Mraize'>Mraize</a> and <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> contains a <a target='_blank' href='https://coppermind.net/wiki/Seon'>Seon</a>."
-                                }
+                                },
+				{
+				    "target": "mb7",
+				    "type": "major",
+				    "description": "WIP"
+				}
                             ]
                         },
                         {
@@ -404,7 +409,12 @@
                                     "target": "sa4",
                                     "type": "egg",
                                     "description": "The <a target='_blank' href='https://coppermind.net/wiki/Fused'>Fused</a> refer to <a target='_blank' href='https://coppermind.net/wiki/aluminum'>aluminum</a> as Ralkalest."
-                                }
+                                },
+				{
+				    "target": "mb7",
+				    "type": "major",
+				    "description": "WIP"
+				}
                             ]
                         },
                         {
@@ -684,7 +694,7 @@
                                 {
                                     "id": "nazh",
                                     "type": "mention",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> is 'the huanted man' in 'The Ghastly Gondola!' story in <a target='_blank' href='https://coppermind.net/wiki/The_New_Ascendancy'>The New Ascendancy</a> broadsheet. (note his 'shadows' curse) <a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> and <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> are also the 'K or N' referred to in the 'Do your metal tools speak to you?' ad in the broadsheet."
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> is 'the haunted man' in 'The Ghastly Gondola!' story in <a target='_blank' href='https://coppermind.net/wiki/The_New_Ascendancy'>The New Ascendancy</a> broadsheet. (note his 'shadows' curse) <a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> and <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> are also the 'K or N' referred to in the 'Do your metal tools speak to you?' ad in the broadsheet."
                                 },
                                 {
                                     "id": "ars",
@@ -723,6 +733,22 @@
                                 "publication": 2022.11,
                                 "chronology": 8.4
                             },
+                            "appearances": [
+                                {
+                                    "id": "hoid",
+                                    "type": "appearance",
+                                    "description": "WIP"
+                                },
+                                {
+                                    "id": "nazh",
+                                    "type": "mention",
+                                    "description": "WIP"
+                                },
+                                {
+                                    "id": "ars",
+                                    "type": "appearance"
+                                }
+                            ],
                             "categories": [ "mistborn", "plan", "forthcoming", "novel" ]
                         },
                         {
@@ -891,7 +917,12 @@
                                     "target": "sa4",
                                     "type": "significant",
                                     "description": "Thaidakar, leader of the <a target='_blank' href='https://coppermind.net/wiki/Ghostbloods'>Ghostbloods</a> is <a target='_blank' href='https://coppermind.net/wiki/Kelsier'>Kelsier</a>, with the fight between him and <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> in <a target='_blank' href='https://coppermind.net/wiki/Mistborn:_Secret_History'>Secret History</a> specifically referenced. <a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a> is referenced in <a target='_blank' href='https://coppermind.net/wiki/Ialai'>Ialai's</a> notes. The device used by the <a target='_blank' href='https://coppermind.net/wiki/honorspren'>honorspren</a> to store <a target='_blank' href='https://coppermind.net/wiki/Stormlight'>Stormlight</a> came from the <a target='_blank' href='https://coppermind.net/wiki/Ire'>Ire</a>."
-                                }
+                                },
+				{
+				    "target": "mb7",
+				    "type": "significant",
+				    "description": "WIP"
+				}
                             ]
                         },
                         {
@@ -974,7 +1005,12 @@
                                     "target": "sa4",
                                     "type": "major",
                                     "description": "<a target='_blank' href='https://coppermind.net/wiki/Nightblood'>Nightblood</a> is used to kill <a target='_blank' href='https://coppermind.net/wiki/Rayse'>Rayse</a>. <a target='_blank' href='https://coppermind.net/wiki/Ialai'>Ialai's</a> notes mention <a target='_blank' href='https://coppermind.net/wiki/Nalthis'>Nalthis</a>. <a target='_blank' href='https://coppermind.net/wiki/Zahel'>Zahel</a> uses <a target='_blank' href='https://coppermind.net/wiki/Awakening'>Awakening</a> in his fight against <a target='_blank' href='https://coppermind.net/wiki/Kaladin'>Kaladin</a> and explains that he is a <a target='_blank' href='https://coppermind.net/wiki/Cognitive_Shadow'>Cognitive Shadow</a>. The coin <a target='_blank' href='https://coppermind.net/wiki/Adolin'>Adolin</a> gives to <a target='_blank' href='https://coppermind.net/wiki/Kaladin'>Kaladin</a> and some merchants in <a target='_blank' href='https://coppermind.net/wiki/Lasting_Integrity'>Lasting Integrity</a> are from <a target='_blank' href='https://coppermind.net/wiki/Nalthis'>Nalthis</a>. <a target='_blank' href='https://coppermind.net/wiki/Endowment'>Endowment</a> is referenced in the <a target='_blank' href='https://coppermind.net/wiki/Rhythm_of_War/Epigraphs'>Chapter 24 epigraph</a>. <a target='_blank' href='https://coppermind.net/wiki/Odium'>Odium</a> tampers with <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid's</a> <a target='_blank' href='https://coppermind.net/wiki/BioChromatic_Breath'>Breath</a> in the Epilogue."
-                                }
+                                },
+				{
+				    "target": "mb7",
+				    "type": "significant",
+				    "description": "WIP"
+				}
                             ]
                         },
                         {
@@ -1073,7 +1109,12 @@
                                     "target": "au",
                                     "type": "minor",
                                     "description": "The <a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a> essay covers details about <a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a> and makes mentions of <a target='_blank' href='https://coppermind.net/wiki/Odium'>Odium</a>'s past."
-                                }
+                                },
+				{
+				    "target": "mb7",
+				    "type": "minor",
+				    "description": "WIP"
+				}
                             ]
                         },
                         {
@@ -1137,7 +1178,12 @@
                                     "target": "twokp",
                                     "type": "minor",
                                     "description": "<a target='_blank' href='https://coppermind.net/wiki/The_Way_of_Kings_Prime'>The Way of Kings Prime</a>, written in 2002, is the original draft of <a target='_blank' href='https://coppermind.net/wiki/The_Way_of_Kings'>The Way of Kings</a>. Only small excerpts were released prior to <a target='_blank' href='https://coppermind.net/wiki/The_Way_of_Kings'>Oathbringer</a> as Brandon felt it contained spoilers for certain ideas through that book. It was self-published as a Sanderson Curiosity in July 2020."
-                                }
+                                },
+				{
+				    "target": "mb7",
+				    "type": "minor",
+				    "description": "WIP"
+				}
                             ]
                         },
                         {
@@ -1198,7 +1244,12 @@
                                     "target": "mb2",
                                     "type": "minor",
                                     "description": "<a target='_blank' href='https://coppermind.net/wiki/Ati'>Ati</a> speaks to <a target='_blank' href='https://coppermind.net/wiki/Vin'>Vin</a> and others with <a target='_blank' href='https://coppermind.net/wiki/Ruin'>Ruin's</a> <a target='_blank' href='https://coppermind.net/wiki/Rhythm#The_Pure_Tones'>Pure Tone</a>. The <a target='_blank' href='https://coppermind.net/wiki/Well_of_Ascension'>Well of Ascension</a> pulses with <a target='_blank' href='https://coppermind.net/wiki/Preservation'>Preservation's</a> <a target='_blank' href='https://coppermind.net/wiki/Rhythm#The_Pure_Tones'>Pure Tone</a>"
-                                }
+                                },
+				{
+				    "target": "mb7",
+				    "type": "significant",
+				    "description": "WIP"
+				}
                             ]
                         },
                         {
@@ -1434,7 +1485,12 @@
                                     "target": "sa4",
                                     "type": "minor",
                                     "description": "<a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a> is referenced in <a target='_blank' href='https://coppermind.net/wiki/Ialai'>Ialai's</a> notes."
-                                }
+                                },
+				{
+				    "target": "mb7",
+				    "type": "minor",
+				    "description": "WIP"
+				}
                             ]
                         },
                         {
@@ -1728,7 +1784,14 @@
                             "sorting": {
                                 "chronology": 1.1
                             },
-                            "categories": [ "dragonsteel", "plan", "unpublished", "novel" ]
+                            "categories": [ "dragonsteel", "plan", "unpublished", "novel" ],
+			    "connections": [
+				{
+				    "target": "mb7",
+				    "type": "egg",
+				    "description": "WIP"
+				}
+			]
                         },
                         {
                             "id": "d2",
@@ -1901,7 +1964,12 @@
                                     "target": "sa4",
                                     "type": "minor",
                                     "description": "<a target='_blank' href='https://coppermind.net/wiki/Devotion'>Devotion</a> and <a target='_blank' href='https://coppermind.net/wiki/Dominion'>Dominion</a> are referenced in the <a target='_blank' href='https://coppermind.net/wiki/Rhythm_of_War/Epigraphs'>Chapter 26 Epigraph</a>. <a target='_blank' href='https://coppermind.net/wiki/Ambition'>Ambition's</a> struggle with <a target='_blank' href='https://coppermind.net/wiki/Odium'>Odium</a> is referenced in the <a target='_blank' href='https://coppermind.net/wiki/Rhythm_of_War/Epigraphs'>Chapter 27 Epigraph</a>."
-                                }
+                                },
+				{
+				    "target": "mb7",
+				    "type": "minor",
+				    "description": "WIP"
+				}
                             ]
                         }
                     ]
@@ -1973,7 +2041,12 @@
                                     "target": "sa4",
                                     "type": "egg",
                                     "description": "<a target='_blank' href='https://coppermind.net/wiki/Foil'>Foil</a> is said to be seeking 'control over the <a target='_blank' href='https://coppermind.net/wiki/Aether'>aethers</a>'."
-                                }
+                                },
+				{
+				    "target": "mb7",
+				    "type": "minor",
+				    "description": "WIP"
+				}
                             ]
                         },
                         {
@@ -1997,7 +2070,14 @@
                                     "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is the 'Imperial Fool'."
                                 }
                             ],
-                            "categories": [ "no-series", "short", "apocryphal", "noncanon" ]
+                            "categories": [ "no-series", "short", "apocryphal", "noncanon" ],
+			    "connections":[
+				{
+				    "target": "mb7",
+				    "type": "egg",
+				    "description": "WIP"
+				}
+			    ]
                         },
                         {
                             "id": "twokp",

--- a/public/data.json
+++ b/public/data.json
@@ -324,7 +324,7 @@
 								{
 									"target": "mb7",
 									"type": "major",
-									"description": "(WIP) Codenames is Kaise; she communicate with Kelsier using Seon Dao in chapter 40. Shay-I (Moonlight) uses AonDor in chapter 54."
+									"description": "(WIP) Codenames is Kaise; she communicate with Kelsier using Seon Dao in Chapter 40. Shay-I (Moonlight) uses AonDor in Chapter 54."
 								}
 							]
 						},
@@ -1141,7 +1141,7 @@
 								{
 									"target": "mb7",
 									"type": "significant",
-									"description": "(WIP) Nalthis is mentionned in chapter 39. Moonlight describes an Awakened lock in chapter 40."
+									"description": "(WIP) Nalthis is mentionned in Chapter 39. Moonlight describes an Awakened lock in Chapter 40."
 								}
 							]
 						},
@@ -1208,7 +1208,7 @@
 								{
 									"target": "mb7",
 									"type": "minor",
-									"description": "(WIP) Moonlight mentions Odium in chapter 20. Wayne buys some chouta from a street vendor in chapter 32. Codenames mentions Roshar and the Thaylen language in chapter 39."
+									"description": "(WIP) Moonlight mentions Odium in Chapter 20. Codenames mentions Roshar and the Thaylen language in Chapter 39."
 								}
 							]
 						},
@@ -1267,7 +1267,7 @@
 								{
 									"target": "mb7",
 									"type": "egg",
-									"description": "(WIP) Dlavil is Iyatil's Brother"
+									"description": "(WIP) Wayne buys some chouta from a street vendor in Chapter 32. Dlavil is Iyatil's Brother"
 								}
 							]
 						},
@@ -2302,7 +2302,7 @@
 								{
 									"target": "mb7",
 									"type": "minor",
-									"description": "(WIP) Moonlight references the death of Devotion and Dominion in chapter 40. Autonomy currently resides in the Taldain system."
+									"description": "(WIP) Moonlight references the death of Devotion and Dominion in Chapter 40. Autonomy currently resides in the Taldain system."
 								}
 							]
 						}

--- a/public/data.json
+++ b/public/data.json
@@ -1,2142 +1,2505 @@
 {
-    "base-separation": 3.21,
-    "connections": [
-        {
-            "id": "major",
-            "description": "Major Connections",
-            "details": "There is at least one major connection between the books which will enhance your understanding of the plot and the Cosmere. Reading in this order is highly recommended, and reading out of order may be spoilery.",
-            "color": "#770000",
-            "highlightColor": "#DB1E1E",
-            "width": 2
-        },
-        {
-            "id": "significant",
-            "description": "Significant Connections",
-            "details": "There is at least one significant connection between the books which may enhance your understanding of the plot and the Cosmere. Reading in this order is recommended.",
-            "color": "#a0470d",
-            "highlightColor": "#a0470d",
-            "width": 2,
-            "dash": "4 2"
-        },
-        {
-            "id": "minor",
-            "description": "Minor Connections",
-            "details": "There is at least one minor connection between the books which may enhance your understanding of the plot and Cosmere in a small way.",
-            "color": "#a09713",
-            "highlightColor": "#a09713",
-            "width": 1,
-            "dash": "3",
-            "activeByDefault": false
-        },
-        {
-            "id": "egg",
-            "description": "Easter Eggs",
-            "details": "There is at least one subtle reference between the books which may hint at something bigger going on. Easter eggs may be very difficult to spot unaided.",
-            "color": "#4d4d4d",
-            "highlightColor": "#4d4d4d",
-            "width": 1,
-            "dash": "2",
-            "activeByDefault": false
-        }
-    ],
-    "layers": [
-        {
-            "id": "pub-status",
-            "name": "Publication Status",
-            "categories": [
-                {
-                    "id": "published",
-                    "description": "Published",
-                    "details": "Published, canonical works.",
-                    "color": "#FFFFFF"
-                },
-                {
-                    "id": "forthcoming",
-                    "description": "Forthcoming",
-                    "details": "Forthcoming works with a planned release month or which are being actively worked on. Expected publication dates may be in parenthesis. Titles may be tentative.",
-                    "color": "#888888"
-                },
-                {
-                    "id": "unpublished",
-                    "description": "Future Plans",
-                    "details": "Includes all planned future cosmere stories. Likelihood of publication varies. Expected publication dates may be in parenthesis. Titles are tentative.",
-                    "color": "#505050"
-                },
-                {
-                    "id": "noncanon",
-                    "description": "Other",
-                    "details": "Uncanonical works which are publicly available, both excerpts and complete.",
-                    "color": "#735a45"
-                }
-            ]
-        },
-        {
-            "id": "series",
-            "name": "Series",
-            "startActive": true,
-            "categories": [
-                {
-                    "id": "elantris",
-                    "description": "Elantris",
-                    "details": "Elantris and its sequels.",
-                    "color": "#58b06e"
-                },
-                {
-                    "id": "mistborn",
-                    "description": "Mistborn",
-                    "details": "Mistborn (all eras)",
-                    "color": "#9973bf"
-                },
-                {
-                    "id": "warbreaker",
-                    "description": "Warbreaker",
-                    "details": "Warbreaker and its sequel.",
-                    "color": "#de4343"
-                },
-                {
-                    "id": "stormlight",
-                    "description": "Stormlight Archive",
-                    "details": "The Stormlight Archive",
-                    "color": "#2aa1d4"
-                },
-                {
-                    "id": "white-sand",
-                    "description": "White Sand",
-                    "details": "White Sand and its sequels.",
-                    "color": "#d4c955"
-                },
-                {
-                    "id": "dragonsteel",
-                    "description": "Dragonsteel",
-                    "details": "Dragonsteel",
-                    "color": "#d98a41"
-                },
-                {
-                    "id": "aether",
-                    "description": "Aether",
-                    "details": "Aether series",
-                    "color": "#e3a1e3"
-                },
-                {
-                    "id": "no-series",
-                    "description": "Non-series Stories",
-                    "details": "Stories not part of a series.",
-                    "color": "#A0A0A0"
-                }
-            ]
-        },
-        {
-            "id": "reading-order",
-            "name": "Reading Order",
-            "categories": [
-                {
-                    "id": "phase1",
-                    "description": "Phase 1 - Essential",
-                    "details": "Essential Phase 1 stories should be read before moving to Phase 2.",
-                    "color": "#00b02b"
-                },
-                {
-                    "id": "phase1b",
-                    "description": "Phase 1 - Secondary",
-                    "details": "Secondary Phase 1 stories may be read during Phase 1 or anytime after.",
-                    "color": "#7bb088"
-                },
-                {
-                    "id": "phase2",
-                    "description": "Phase 2 - Essential",
-                    "details": "Essential Phase 2 stories should be read after all essential Phase 1 works and before moving to Phase 3.",
-                    "color": "#0094d4"
-                },
-                {
-                    "id": "phase2b",
-                    "description": "Phase 2 - Secondary",
-                    "details": "Secondary Phase 2 stories may be read during Phase 2 or anytime after.",
-                    "color": "#8abdd4"
-                },
-                {
-                    "id": "plan",
-                    "description": "Unpublished - Future Plans",
-                    "details": "Includes all planned future cosmere stories. Likelihood of publication varies. Known publication dates may be in parenthesis. Titles are tentative.",
-                    "color": "#505050"
-                },
-                {
-                    "id": "apocryphal",
-                    "description": "Unpublished - Apocryphal",
-                    "details": "Includes unpublished, apocryphal stories. Some elements may be part of the official continuity. Some may be published in the future while others will not.",
-                    "color": "#735a45"
-                }
-            ]
-        },
-        {
-            "id": "formats",
-            "name": "Formats",
-            "startCollapsed": true,
-            "categories": [
-                {
-                    "id": "novel",
-                    "description": "Novels",
-                    "details": "Full novels.",
-                    "color": "#fc4422"
-                },
-                {
-                    "id": "graphic",
-                    "description": "Graphic Novels",
-                    "details": "Graphic novels.",
-                    "style": "italic",
-                    "color": "#fe8062"
-                },
-                {
-                    "id": "novella",
-                    "description": "Novellas",
-                    "details": "Novellas.",
-                    "style": "italic",
-                    "color": "#ffc8ba"
-                },
-                {
-                    "id": "short",
-                    "description": "Short Stories",
-                    "details": "Short stories.",
-                    "style": "italic",
-                    "color": "#fbe8e6"
-                }
-            ]
-        }
-    ],
-    "sorting": [
-        {
-            "id": "order",
-            "description": "Reading order"
-        },
-        {
-            "id": "publication",
-            "description": "Publication date"
-        },
-        {
-            "id": "chronology",
-            "description": "Cosmere timeline"
-        }
-    ],
-    "appearances": [
-        {
-            "id": "hoid",
-            "description": "Hoid",
-            "initial": "H",
-            "color": "#A0A0A0",
-            "details": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a>'s appearances (solid) and mentions (outline)."
-        },
-        {
-            "id": "khriss",
-            "description": "Khriss",
-            "initial": "K",
-            "color": "#A0A0A0",
-            "details": "<a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a>'s appearances (solid) and mentions (outline), not counting the <a target='_blank' href='https://coppermind.net/wiki/Ars_Arcanum'>Ars Arcanum</a>."
-        },
-        {
-            "id": "nazh",
-            "description": "Nazh",
-            "initial": "N",
-            "color": "#A0A0A0",
-            "details": "<a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a>'s appearances (solid) and mentions (outline)."
-        },
-        {
-            "id": "ars",
-            "description": "Ars Arcanum",
-            "initial": "A",
-            "color": "#A0A0A0",
-            "details": "Stories that include an <a target='_blank' href='https://coppermind.net/wiki/Ars_Arcanum'>Ars Arcanum</a>."
-        }
-    ],
-    "books": [
-        {
-            "label": "Sel",
-            "color": "#58b06e",
-            "children": [
-                {
-                    "label": "Elantris",
-                    "children": [
-                        {
-                            "id": "elantris",
-                            "title": "Elantris",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Elantris'>Elantris</a>",
-                            "series": "Elantris",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Sel'>Sel</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Selish_system'>Selish system</a>",
-                            "publication": "April 2005",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/298/#e9926'>Occurs long before Mistborn Era 1, but not thousands of years before.</a>",
-                            "sorting": {
-				"order": 1.3,
-                                "publication": 2005.04,
-                                "chronology": 3.1
-                            },
-                            "appearances": [
-                                {
-                                    "id": "hoid",
-                                    "type": "appearance",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a>'s first appearance. <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is the beggar that works with <a target='_blank' href='https://coppermind.net/wiki/Sarene'>Sarene</a> in <a target='_blank' href='https://coppermind.net/wiki/Summary:Elantris#Chapter_58'>Chapter 58</a>. The tenth anniversary edition includes <a target='_blank' href='https://coppermind.net/wiki/Summary:Elantris#Postscript'>a postscript</a> with <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> in it."
-                                },
-                                {
-                                    "id": "nazh",
-                                    "type": "mention",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a>'s annotations can be found on the map of <a target='_blank' href='https://coppermind.net/wiki/Sycla'>Sycla</a>."
-                                },
-                                {
-                                    "id": "ars",
-                                    "type": "appearance"
-                                }
-                            ],
-                            "categories": [ "elantris", "phase1", "published", "novel" ],
-                            "connections": [
-                                {
-                                    "target": "tes",
-                                    "type": "minor",
-                                    "description": "The map in <a target='_blank' href='https://coppermind.net/wiki/Elantris'>Elantris</a> refers to '<a target='_blank' href='https://coppermind.net/wiki/Rose_Empire'>Rose Barbarians</a>'. There are mentions of <a target='_blank' href='https://coppermind.net/wiki/Svorden'>Svorden</a>, <a target='_blank' href='https://coppermind.net/wiki/Teod'>Teod</a>, and <a target='_blank' href='https://coppermind.net/wiki/Sycla'>Sycla</a>. When escaping the palace, <a target='_blank' href='https://coppermind.net/wiki/Shai'>Shai</a> runs into a <a target='_blank' href='https://coppermind.net/wiki/Shu-Dereth'>Derethi priest</a> (wearing red armor). When she steals the painting she inscribes an <a target='_blank' href='https://coppermind.net/wiki/Aon'>Aon Reo</a> in its place."
-                                },
-                                {
-                                    "target": "msh",
-                                    "type": "significant",
-                                    "description": "The <a target='_blank' href='https://coppermind.net/wiki/Ire'>Ire</a> are <a target='_blank' href='https://coppermind.net/wiki/Elantrian'>Elantrians</a>. Their symbol is <a target='_blank' href='https://coppermind.net/wiki/Aon'>Aon Ire</a>."
-                                },
-                                {
-                                    "target": "sa1",
-                                    "type": "egg",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Galladon'>Galladon</a> appears in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Way_of_Kings#Interlude_I-1:_Ishikk'>Interlude I-1</a> as 'Grump'. Note his use of 'sule' (friend) and 'kolo' (understand) as well as the <a target='_blank' href='https://coppermind.net/wiki/Duladel'>Dula</a> word 'kayana' (crazy). Also, <a target='_blank' href='https://coppermind.net/wiki/Aona'>Aona</a> and <a target='_blank' href='https://coppermind.net/wiki/Skai'>Skai</a> are mentioned in the <a target='_blank' href='https://coppermind.net/wiki/https://coppermind.net/wiki/The_Way_of_Kings/Epigraphs#The_Letter'>Chapter 22 epigraph</a>."
-                                },
-                                {
-                                    "target": "sa3",
-                                    "type": "minor",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Riino'>Riino</a>, the lighthouse owner in <a target='_blank' href='https://coppermind.net/wiki/Summary:Oathbringer#Chapter_97:_Riino'>Chapter 97</a>, is the <a target='_blank' href='https://coppermind.net/wiki/Hoed'>Hoed</a> <a target='_blank' href='https://coppermind.net/wiki/Raoden'>Raoden</a> and <a target='_blank' href='https://coppermind.net/wiki/Galladon'>Galladon</a> lowered into the <a target='_blank' href='https://coppermind.net/wiki/Devotion's_Perpendicularity'>mountain lake</a>."
-                                },
-                                {
-                                    "target": "au",
-                                    "type": "minor",
-                                    "description": "The nature of <a target='_blank' href='https://coppermind.net/wiki/Sel'>Sel</a>'s magic is discussed in the <a target='_blank' href='https://coppermind.net/wiki/Selish_system'>Selish system</a> essay."
-                                },
-                                {
-                                    "target": "sa4",
-                                    "type": "minor",
-                                    "description": "The communication box used by <a target='_blank' href='https://coppermind.net/wiki/Shallan'>Shallan</a> to communicate with <a target='_blank' href='https://coppermind.net/wiki/Mraize'>Mraize</a> and <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> contains a <a target='_blank' href='https://coppermind.net/wiki/Seon'>Seon</a>."
-                                },
-				{
-				    "target": "mb7",
-				    "type": "major",
-				    "description": "WIP"
-				}
-                            ]
-                        },
-                        {
-                            "id": "thoe",
-                            "title": "The Hope of Elantris",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Hope_of_Elantris'>The Hope of Elantris</a>",
-                            "series": "Elantris",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Sel'>Sel</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Selish_system'>Selish system</a>",
-                            "au": "Included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
-                            "link": "<a target='_blank' href='https://brandonsanderson.com/elantris-the-hope-of-elantris'>Full text on Brandon's website.</a>",
-                            "padding": 12,
-                            "publication": "January 2006",
-                            "chronology": "Shortly after the events of Elantris, and concerning events during the end of that book.",
-                            "sorting": {
-				"order": 1.31,
-                                "publication": 2006.01,
-                                "chronology": 3.11
-                            },
-                            "categories": [ "elantris", "phase1b", "published", "short" ]
-                        },
-                        {
-                            "id": "elantris2",
-                            "title": "Elantris 2",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Elantris_sequel'>Elantris 2</a>",
-                            "series": "Elantris",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Sel'>Sel</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Selish_system'>Selish system</a>",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/395/#e13072'>A short time jump is planned between Elantris books, with the original main characters still being alive.</a>",
-                            "sorting": {
-                                "chronology": 3.2
-                            },
-                            "categories": [ "elantris", "plan", "unpublished", "novel" ]
-                        },
-                        {
-                            "id": "elantris3",
-                            "title": "Elantris 3",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Elantris_finale'>Elantris 3</a>",
-                            "series": "Elantris",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Sel'>Sel</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Selish_system'>Selish system</a>",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/395/#e13072'>A short time jump is planned between Elantris books, with the original main characters still being alive.</a>",
-                            "sorting": {
-                                "chronology": 3.3
-                            },
-                            "categories": [ "elantris", "plan", "unpublished", "novel" ]
-                        }
-                    ]
-                },
-                {
-                    "children": [
-                        {
-                            "id": "tes",
-                            "title": "The Emperor's Soul",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Emperor&#39s_Soul'>The Emperor's Soul</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Sel'>Sel</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Selish_system'>Selish system</a>",
-                            "au": "Included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
-                            "publication": "November 2012",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/109/#e1410'>After Elantris, but within the characters' lifetimes.</a> Note this could place it prior to Elantris 2 and/or 3.",
-                            "sorting": {
-				"order": 1.4,
-                                "publication": 2012.11,
-                                "chronology": 3.5
-                            },
-                            "appearances": [
-                                {
-                                    "id": "hoid",
-                                    "type": "mention",
-                                    "description": "The 'Imperial Fool' is <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a>."
-                                }
-                            ],
-                            "categories": [ "no-series", "phase1b", "published", "novella" ],
-                            "connections": [
-                                {
-                                    "target": "imperial-fool",
-                                    "type": "major",
-                                    "description": "A deleted prologue that contains some canonical elements."
-                                },
-                                {
-                                    "target": "au",
-                                    "type": "minor",
-                                    "description": "The nature of <a target='_blank' href='https://coppermind.net/wiki/Sel'>Sel</a>'s magic is discussed in the <a target='_blank' href='https://coppermind.net/wiki/Selish_system'>Selish system</a> essay."
-                                },
-                                {
-                                    "target": "sa4",
-                                    "type": "egg",
-                                    "description": "The <a target='_blank' href='https://coppermind.net/wiki/Fused'>Fused</a> refer to <a target='_blank' href='https://coppermind.net/wiki/aluminum'>aluminum</a> as Ralkalest."
-                                },
-				{
-				    "target": "mb7",
-				    "type": "major",
-				    "description": "WIP"
-				}
-                            ]
-                        },
-                        {
-                            "id": "tes2",
-                            "title": "The Emperor's Soul sequel",
-                            "title2": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>Untitled Emperor's Soul sequel</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Sel'>Sel</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Selish_system'>Selish system</a>",
-                            "categories": [ "no-series", "plan", "unpublished", "novella" ]
-                        }
-                    ]
-                }
-            ]
-        },
-        {
-            "label": "Scadrial",
-            "color": "#9973bf",
-            "children": [
-                {
-                    "label": "Mistborn<br>Era 1",
-                    "children": [
-                        {
-                            "id": "mb1",
-                            "title": "Mistborn: The Final Empire",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn:_The_Final_Empire'>Mistborn: The Final Empire</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 1)",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-                            "publication": "July 2006",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/176/#e8494'>Mistborn Era 1 occurs prior to The Stormlight Archive.",
-                            "sorting": {
-				"order": 1.11,
-                                "publication": 2006.07,
-                                "chronology": 4.1
-                            },
-                            "appearances": [
-                                {
-                                    "id": "hoid",
-                                    "type": "appearance",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Kelsier'>Kelsier</a> meets with <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> in <a target='_blank' href='https://coppermind.net/wiki/Summary:Mistborn:_The_Final_Empire#Chapter_19'>Chapter 19</a>."
-                                },
-                                {
-                                    "id": "nazh",
-                                    "type": "mention",
-                                    "description": "Annotations by <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> can be found on the map of <a target='_blank' href='https://coppermind.net/wiki/Luthadel'>Luthadel</a>."
-                                },
-                                {
-                                    "id": "ars",
-                                    "type": "appearance"
-                                }
-                            ],
-                            "categories": [ "mistborn", "phase1", "published", "novel" ]
-                        },
-                        {
-                            "id": "11m",
-                            "title": "The Eleventh Metal",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Eleventh_Metal'>The Eleventh Metal</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 1)",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-                            "au": "Included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
-                            "padding": 12,
-                            "publication": "December 2011",
-                            "chronology": "Concerns Kelsier's training, years before Mistborn: The Final Empire.",
-                            "sorting": {
-				"order": 1.14,
-                                "publication": 2011.12,
-                                "chronology": 4.09
-                            },
-                            "categories": [ "mistborn", "short", "phase1b", "published" ]
-                        },
-                        {
-                            "id": "mb2",
-                            "title": "The Well of Ascension",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Well_of_Ascension'>The Well of Ascension</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 1)",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-                            "publication": "August 2007",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/176/#e8494'>Mistborn Era 1 occurs prior to The Stormlight Archive.",
-                            "sorting": {
-				"order": 1.12,
-                                "publication": 2007.08,
-                                "chronology": 4.2
-                            },
-                            "appearances": [
-                                {
-                                    "id": "hoid",
-                                    "type": "appearance",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is among the <a target='_blank' href='https://coppermind.net/wiki/Terris'>Terris</a> refugees in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Well_of_Ascension#Chapter_56'>Chapter 56</a>, <a target='_blank' href='https://wob.coppermind.net/events/130/#e1552'>according to Brandon</a>."
-                                },
-                                {
-                                    "id": "nazh",
-                                    "type": "mention",
-                                    "description": "Annotations by <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> can be found on the map of <a target='_blank' href='https://coppermind.net/wiki/Luthadel'>Luthadel</a>."
-                                },
-                                {
-                                    "id": "ars",
-                                    "type": "appearance"
-                                }
-                            ],
-                            "categories": [ "mistborn", "phase1", "published", "novel" ],
-                            "connections": [
-                                {
-                                    "target": "wb",
-                                    "type": "egg",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Lemex%27s_nurse'>Lemex's nurse</a> is a <a target='_blank' href='https://coppermind.net/wiki/Terris'>Terriswoman</a>."
-                                }
-                            ]
-                        },
-                        {
-                            "id": "mb3",
-                            "title": "The Hero of Ages",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Hero_of_Ages'>The Hero of Ages</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 1)",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-                            "publication": "October 2008",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/176/#e8494'>Mistborn Era 1 occurs prior to The Stormlight Archive.",
-                            "sorting": {
-				"order": 1.13,
-                                "publication": 2008.10,
-                                "chronology": 4.3
-                            },
-                            "appearances": [
-                                {
-                                    "id": "hoid",
-                                    "type": "mention",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is the informant that <a target='_blank' href='https://coppermind.net/wiki/Vin'>Vin</a> was supposed to meet with in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Hero_of_Ages#Chapter_27'>Chapter 27</a>."
-                                },
-                                {
-                                    "id": "nazh",
-                                    "type": "mention",
-                                    "description": "Annotations by <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> can be found on the map of <a target='_blank' href='https://coppermind.net/wiki/Luthadel'>Luthadel</a>."
-                                },
-                                {
-                                    "id": "ars",
-                                    "type": "appearance"
-                                }
-                            ],
-                            "categories": [ "mistborn", "phase1", "published", "novel" ],
-                            "connections": [
-                                {
-                                    "target": "sa1",
-                                    "type": "egg",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Demoux'>Demoux</a> appears in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Way_of_Kings#Interlude_I-1:_Ishikk'>Interlude I-1</a> as 'Thinker'; <a target='_blank' href='https://coppermind.net/wiki/Ishikk'>Ishikk</a> mishears his name as 'Temoo'. <a target='_blank' href='https://coppermind.net/wiki/Ruin'>Ruin</a>'s <a target='_blank' href='https://coppermind.net/wiki/vessel'>vessel</a>, <a target='_blank' href='https://coppermind.net/wiki/Ati'>Ati</a>, is mentioned in the <a target='_blank' href='https://coppermind.net/wiki/https://coppermind.net/wiki/The_Way_of_Kings/Epigraphs#The_Letter'>Chapter 18 epigraph</a>. <a target='_blank' href='https://coppermind.net/wiki/Felt'>Felt</a> worked for the <a target='_blank' href='https://coppermind.net/wiki/House_Venture'>House Venture</a> on <a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>."
-                                },
-                                {
-                                    "target": "sa2",
-                                    "type": "egg",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Wit</a> appears to use <a target='_blank' href='https://coppermind.net/wiki/Allomancy'>emotional Allomancy</a> in <a target='_blank' href='https://coppermind.net/wiki/Summary:Words_of_Radiance#Chapter_45:_Middlefest'>Chapter 45</a>."
-                                },
-                                {
-                                    "target": "sa3",
-                                    "type": "significant",
-                                    "description": "The <a target='_blank' href='https://coppermind.net/wiki/Oathbringer/Epigraphs#Letters'>Part 2 epigraphs</a> include <a target='_blank' href='https://coppermind.net/wiki/Letters#Third_Oathbringer_Letter'>a letter</a> from <a target='_blank' href='https://coppermind.net/wiki/Sazed'>Sazed</a> to <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a>. <a target='_blank' href='https://coppermind.net/wiki/Felt'>Felt</a> reveals he is from another world."
-                                },
-                                {
-                                    "target": "au",
-                                    "type": "major",
-                                    "description": "The <a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a> essay discusses the events that occurred in <a target='_blank' href='https://coppermind.net/wiki/The_Hero_of_Ages'>The Hero of Ages</a>."
-                                },
-                                {
-                                    "target": "sa4",
-                                    "type": "significant",
-                                    "description": "The <a target='_blank' href='https://coppermind.net/wiki/Rhythm_of_War/Epigraphs'>Part 2 Epigraphs</a> are a letter from <a target='_blank' href='https://coppermind.net/wiki/Harmony'>Harmony</a>. <a target='_blank' href='https://coppermind.net/wiki/Fabrial'>Fabrial</a> metals have similar effects as in the <a target='_blank' href='https://coppermind.net/wiki/Metallic_Arts'>Metalic Arts</a>. <a target='_blank' href='https://coppermind.net/wiki/Gereh'>Gereh</a> and <a target='_blank' href='https://coppermind.net/wiki/Axindweth'>Axindweth</a> are <a target='_blank' href='https://coppermind.net/wiki/Feruchemy'>Feruchemists</a>. <a target='_blank' href='https://coppermind.net/wiki/Raysium'>Raysium</a> is associated with <a target='_blank' href='https://coppermind.net/wiki/Odium'>Odium</a> as <a target='_blank' href='https://coppermind.net/wiki/atium'>atium</a> is associated with <a target='_blank' href='https://coppermind.net/wiki/Ruin'>Ruin</a>."
-                                }
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "label": "Mistborn<br>Era 2",
-                    "children": [
-                        {
-                            "id": "mb4",
-                            "title": "The Alloy of Law",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Alloy_of_Law'>The Alloy of Law</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 2)",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-                            "publication": "November 2011",
-                            "chronology": "Mistborn Era 2 occurs <a target='_blank' href='https://wob.coppermind.net/events/260/#e8747'>after Stormlight Archive book 5</a> and <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>before Stormlight Archive book 6</a>.",
-                            "sorting": {
-				"order": 2.21,
-                                "publication": 2011.11,
-                                "chronology": 8.1
-                            },
-                            "appearances": [
-                                {
-                                    "id": "hoid",
-                                    "type": "appearance",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is the beggar speaking with <a target='_blank' href='https://coppermind.net/wiki/Joshin_Yomen'>Lord Joshin</a> and <a target='_blank' href='https://coppermind.net/wiki/Mi%27chelle_Yomen'>Lady Mi'chelle</a> in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Alloy_of_Law#Chapter_4'>Chapter 4</a>."
-                                },
-                                {
-                                    "id": "nazh",
-                                    "type": "mention",
-                                    "description": "Annotations by <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> can be found on the map of <a target='_blank' href='https://coppermind.net/wiki/Elendel'>Elendel</a>."
-                                },
-                                {
-                                    "id": "ars",
-                                    "type": "appearance"
-                                }
-                            ],
-                            "categories": [ "mistborn", "phase2", "published", "novel" ]
-                        },
-                        {
-                            "id": "jak",
-                            "title": "Allomancer Jak",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Allomancer_Jak_and_the_Pits_of_Eltania'>Allomancer Jak and the Pits of Eltania</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 2)",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-                            "au": "Included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
-                            "padding": 12,
-                            "publication": "August 2014",
-                            "chronology": "Mistborn Era 2 occurs <a target='_blank' href='https://wob.coppermind.net/events/260/#e8747'>after Stormlight Archive book 5</a> and <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>before Stormlight Archive book 6</a>.",
-                            "sorting": {
-				"order": 2.22,
-                                "publication": 2014.08,
-                                "chronology": 8.05
-                            },
-                            "categories": [ "mistborn", "short", "phase2b", "published" ]
-                        },
-                        {
-                            "id": "mb5",
-                            "title": "Shadows of Self",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Shadows_of_Self'>Shadows of Self</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 2)",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-                            "publication": "October 2015",
-                            "chronology": "Mistborn Era 2 occurs <a target='_blank' href='https://wob.coppermind.net/events/260/#e8747'>after Stormlight Archive book 5</a> and <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>before Stormlight Archive book 6</a>.",
-                            "sorting": {
-				"order": 2.23,
-                                "publication": 2015.10,
-                                "chronology": 8.2
-                            },
-                            "appearances": [
-                                {
-                                    "id": "hoid",
-                                    "type": "appearance",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is <a target='_blank' href='https://coppermind.net/wiki/Waxillium_Laddrian'>Wax</a>'s coachman, named in <a target='_blank' href='https://coppermind.net/wiki/Summary:Shadows_of_Self#Chapter_7'>Chapter 7</a>."
-                                },
-                                {
-                                    "id": "ars",
-                                    "type": "appearance"
-                                }
-                            ],
-                            "categories": [ "mistborn", "phase2", "published", "novel" ]
-                        },
-                        {
-                            "id": "mb6",
-                            "title": "The Bands of Mourning",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Bands_of_Mourning'>The Bands of Mourning</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 2)",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-                            "publication": "January 2016",
-                            "chronology": "Mistborn Era 2 occurs <a target='_blank' href='https://wob.coppermind.net/events/260/#e8747'>after Stormlight Archive book 5</a> and <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>before Stormlight Archive book 6</a>.",
-                            "sorting": {
-				"order": 2.24,
-                                "publication": 2016.01,
-                                "chronology": 8.3
-                            },
-                            "appearances": [
-                                {
-                                    "id": "hoid",
-                                    "type": "appearance",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is the beggar who gives <a target='_blank' href='https://coppermind.net/wiki/Waxillium_Laddrian'>Wax</a> a special coin in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Bands_of_Mourning#Chapter_11'>Chapter 11</a>."
-                                },
-                                {
-                                    "id": "khriss",
-                                    "type": "appearance",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> is the woman who dances with <a target='_blank' href='https://coppermind.net/wiki/Waxillium_Laddrian'>Wax</a> in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Bands_of_Mourning#Chapter_12'>Chapter 12</a>. <a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> and <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> are also the 'K or N' referred to in the 'Do your metal tools speak to you?' ad in <a target='_blank' href='https://coppermind.net/wiki/The_New_Ascendancy'>The New Ascendancy</a> broadsheet."
-                                },
-                                {
-                                    "id": "nazh",
-                                    "type": "mention",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> is 'the haunted man' in 'The Ghastly Gondola!' story in <a target='_blank' href='https://coppermind.net/wiki/The_New_Ascendancy'>The New Ascendancy</a> broadsheet. (note his 'shadows' curse) <a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> and <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> are also the 'K or N' referred to in the 'Do your metal tools speak to you?' ad in the broadsheet."
-                                },
-                                {
-                                    "id": "ars",
-                                    "type": "appearance"
-                                }
-                            ],
-                            "categories": [ "mistborn", "phase2", "published", "novel" ],
-                            "connections": [
-                                {
-                                    "target": "sa2",
-                                    "type": "egg",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Iyatil'>Iyatil</a> is of <a target='_blank' href='https://coppermind.net/wiki/Southern_Scadrial'>Southern Scadrian</a> descent."
-                                },
-                                {
-                                    "target": "msh",
-                                    "type": "major",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Kelsier'>Kelsier</a>'s survival is revealed in <a target='_blank' href='https://coppermind.net/wiki/The_Bands_of_Mourning'>The Bands of Mourning</a>."
-                                },
-                                {
-                                    "target": "sotd2",
-                                    "type": "minor",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrian</a> spaceships powered by <a target='_blank' href='https://coppermind.net/wiki/Allomancy'>Allomancy</a> are seen."
-                                }
-                            ]
-                        },
-                        {
-                            "id": "mb7",
-                            "title": "The Lost Metal (2022)",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Lost_Metal'>The Lost Metal</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 2)",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-                            "publication": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>Fall 2022</a>",
-                            "chronology": "Mistborn Era 2 occurs <a target='_blank' href='https://wob.coppermind.net/events/260/#e8747'>after Stormlight Archive book 5</a> and <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>before Stormlight Archive book 6</a>.",
-                            "sorting": {
-                                "publication": 2022.11,
-                                "chronology": 8.4
-                            },
-                            "appearances": [
-                                {
-                                    "id": "hoid",
-                                    "type": "appearance",
-                                    "description": "WIP"
-                                },
-                                {
-                                    "id": "nazh",
-                                    "type": "mention",
-                                    "description": "WIP"
-                                },
-                                {
-                                    "id": "ars",
-                                    "type": "appearance"
-                                }
-                            ],
-                            "categories": [ "mistborn", "plan", "forthcoming", "novel" ]
-                        },
-                        {
-                            "id": "nicki",
-                            "title": "Boatload of Mummies",
-                            "title2": "<a target='_blank' href='https://wob.coppermind.net/events/479/#e15159'>Boatload of Mummies</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 2)",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-                            "chronology": "Mistborn Era 2 occurs <a target='_blank' href='https://wob.coppermind.net/events/260/#e8747'>after Stormlight Archive book 5</a> and <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>before Stormlight Archive book 6</a>.",
-                            "padding": 12,
-                            "sorting": {
-                                "chronology": 8.5
-                            },
-                            "categories": [ "mistborn", "short", "plan", "unpublished" ]
-                        }
-                    ]
-                },
-                {
-                    "label": "Mistborn<br>Era 3",
-                    "children": [
-                        {
-                            "id": "mb8",
-                            "title": "Mistborn Era 3 Book 1",
-                            "title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=mistborn+era+3'>Mistborn Era 3 Book 1</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 3)",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>Fifty to seventy years after Mistborn Era 2. After Stormlight Archive book 10.</a> Prior to Mistborn Era 4.",
-                            "publication": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>2024 (best guess)</a>",
-                            "sorting": {
-                                "chronology": 10.1,
-								"publication": 2024
-                            },
-                            "categories": [ "mistborn", "plan", "unpublished", "novel" ]
-                        },
-                        {
-                            "id": "mb9",
-                            "title": "Mistborn Era 3 Book 2",
-                            "title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=mistborn+era+3'>Mistborn Era 3 Book 2</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 3)",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>Fifty to seventy years after Mistborn Era 2. After Stormlight Archive book 10.</a> Prior to Mistborn Era 4.",
-                            "publication": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>2025 (best guess)</a>",
-                            "sorting": {
-                                "chronology": 10.2,
-								"publication": 2025
-                            },
-                            "categories": [ "mistborn", "plan", "unpublished", "novel" ]
-                        },
-                        {
-                            "id": "mb10",
-                            "title": "Mistborn Era 3 Book 3",
-                            "title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=mistborn+era+3'>Mistborn Era 3 Book 3</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 3)",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>Fifty to seventy years after Mistborn Era 2. After Stormlight Archive book 10.</a> Prior to Mistborn Era 4.",
-                            "publication": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>2026 (best guess)</a>",
-                            "sorting": {
-                                "chronology": 10.3,
-								"publication": 2026
-                            },
-                            "categories": [ "mistborn", "plan", "unpublished", "novel" ]
-                        }
-                    ]
-                },
-                {
-                    "label": "Mistborn<br>Era 4",
-                    "children": [
-                        {
-                            "id": "mb11",
-                            "title": "Mistborn Era 4 Book 1",
-                            "title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=mistborn+era+4'>Mistborn Era 4 Book 1</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 4)",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/182/#e3884'>Mistborn Era 4 is the finale of the cosmere storyline.</a>",
-                            "sorting": {
-                                "chronology": 13.1
-                            },
-                            "categories": [ "mistborn", "plan", "unpublished", "novel" ]
-                        },
-                        {
-                            "id": "mb12",
-                            "title": "Mistborn Era 4 Book 2",
-                            "title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=mistborn+era+4'>Mistborn Era 4 Book 2</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 4)",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/182/#e3884'>Mistborn Era 4 is the finale of the cosmere storyline.</a>",
-                            "sorting": {
-                                "chronology": 13.2
-                            },
-                            "categories": [ "mistborn", "plan", "unpublished", "novel" ]
-                        },
-                        {
-                            "id": "mb13",
-                            "title": "Mistborn Era 4 Book 3",
-                            "title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=mistborn+era+4'>Mistborn Era 4 Book 3</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 4)",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/182/#e3884'>Mistborn Era 4 is the finale of the cosmere storyline.</a>",
-                            "sorting": {
-                                "chronology": 13.3
-                            },
-                            "categories": [ "mistborn", "plan", "unpublished", "novel" ]
-                        }
-                    ]
-                },
-                {
-                    "label": "Other<br>Mistborn",
-                    "children": [
-                        {
-                            "id": "msh",
-                            "title": "Mistborn: Secret History",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn:_Secret_History'>Mistborn: Secret History</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-                            "au": "Included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
-                            "publication": "January 2016",
-                            "chronology": "Happens concurrently with Mistborn Era 1.",
-                            "sorting": {
-				"order": 2.25,
-                                "publication": 2016.01,
-                                "chronology": 4.11
-                            },
-                            "appearances": [
-                                {
-                                    "id": "hoid",
-                                    "type": "appearance",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is 'Drifter'."
-                                },
-                                {
-                                    "id": "khriss",
-                                    "type": "appearance",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Kelsier'>Kelsier</a> meets <a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> and <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> in the <a target='_blank' href='https://coppermind.net/wiki/Cognitive_Realm'>Cognitive Realm</a>."
-                                },
-                                {
-                                    "id": "nazh",
-                                    "type": "appearance",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Kelsier'>Kelsier</a> meets <a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> and <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> in the <a target='_blank' href='https://coppermind.net/wiki/Cognitive_Realm'>Cognitive Realm</a>."
-                                }
-                            ],
-                            "categories": [ "mistborn", "novella", "phase2", "published" ],
-                            "connections": [
-                                {
-                                    "target": "sa1",
-                                    "type": "egg",
-                                    "description": "In <a target='_blank' href='https://coppermind.net/wiki/Summary:Mistborn:_Secret_History#Chapter_2_5'>Part 5 Chapter 2</a> <a target='_blank' href='https://coppermind.net/wiki/Kelsier'>Kelsier</a> sees an <a target='_blank' href='https://coppermind.net/wiki/Fabrial'>alerter fabrial</a> (the glowing yellow gemstone in a golden metal lattice)."
-                                },
-                                {
-                                    "target": "sa2",
-                                    "type": "egg",
-                                    "description": "With powers gained from the <a target='_blank' href='https://coppermind.net/wiki/lerasium'>lerasium</a> he took, <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> uses <a target='_blank' href='https://coppermind.net/wiki/Allomancy'>emotional Allomancy</a> in <a target='_blank' href='https://coppermind.net/wiki/Summary:Words_of_Radiance#Chapter_45:_Middlefest'>Chapter 45</a>."
-                                },
-                                {
-                                    "target": "traveler",
-                                    "type": "major",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> and <a target='_blank' href='https://coppermind.net/wiki/Frost'>Frost</a> discuss the events of <a target='_blank' href='https://coppermind.net/wiki/The_Hero_of_Ages'>The Hero of Ages</a> (and <a target='_blank' href='https://coppermind.net/wiki/Mistborn:_Secret_History'>Mistborn: Secret History</a>)."
-                                },
-                                {
-                                    "target": "sa4",
-                                    "type": "significant",
-                                    "description": "Thaidakar, leader of the <a target='_blank' href='https://coppermind.net/wiki/Ghostbloods'>Ghostbloods</a> is <a target='_blank' href='https://coppermind.net/wiki/Kelsier'>Kelsier</a>, with the fight between him and <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> in <a target='_blank' href='https://coppermind.net/wiki/Mistborn:_Secret_History'>Secret History</a> specifically referenced. <a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a> is referenced in <a target='_blank' href='https://coppermind.net/wiki/Ialai'>Ialai's</a> notes. The device used by the <a target='_blank' href='https://coppermind.net/wiki/honorspren'>honorspren</a> to store <a target='_blank' href='https://coppermind.net/wiki/Stormlight'>Stormlight</a> came from the <a target='_blank' href='https://coppermind.net/wiki/Ire'>Ire</a>."
-                                },
-				{
-				    "target": "mb7",
-				    "type": "significant",
-				    "description": "WIP"
-				}
-                            ]
-                        },
-                        {
-                            "id": "msh2",
-                            "title": "Mistborn: Secret History 2",
-                            "title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=mistborn%3A+secret+history+2'>Mistborn: Secret History 2</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-                            "categories": [ "mistborn", "novella", "plan", "unpublished" ]
-                        },
-						{
-                            "id": "mb-cyberpunk",
-                            "title": "Cyberpunk Mistborn",
-                            "title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?query=cyberpunk%2Bmistborn&date_from=2003-12-05&date_to=2019-11-20&speaker=&ordering=rank'>Cyberpunk Mistborn</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-                            "chronology": "A cyberpunk Mistborn series would be in a <a target='_blank' href='https://wob.coppermind.net/events/34/#e1782'>near-future setting</a>, between Eras 3 and 4.",
-                            "sorting": {
-                                "chronology": 10.7
-                            },
-                            "categories": [ "mistborn", "plan", "unpublished", "novel" ]
-                        }
-                    ]
-                }
-            ]
-        },
-        {
-            "label": "Nalthis",
-            "color": "#de4343",
-            "children": [
-                {
-                    "label": "Warbreaker",
-                    "color": "#de4343",
-                    "children": [
-                        {
-                            "id": "wb",
-                            "title": "Warbreaker",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Warbreaker'>Warbreaker</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Nalthis'>Nalthis</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Nalthian_system'>Nalthian system</a>",
-                            "publication": "June 2009",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/309/#e10273'>Occurs after Mistborn Era 1 and before The Stormlight Archive.</a>",
-                            "link": "Full text: <a target='_blank' href='https://www.brandonsanderson.com/warbreaker-rights-and-downloads/'>Brandon's website</a> | <a target='_blank' href='https://github.com/guusj/books'>Alternate file types</a>",
-			    "sorting": {
-				"order": 1.2,
-                                "publication": 2009.06,
-                                "chronology": 5.1
-                            },
-                            "appearances": [
-                                {
-                                    "id": "hoid",
-                                    "type": "appearance",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is the master storyteller in <a target='_blank' href='https://coppermind.net/wiki/Summary:Warbreaker#Chapter_32'>Chapter 32</a>."
-                                },
-                                {
-                                    "id": "ars",
-                                    "type": "appearance"
-                                }
-                            ],
-                            "categories": [ "warbreaker", "phase1", "published", "novel" ],
-                            "connections": [
-                                {
-                                    "target": "sa2",
-                                    "type": "significant",
-                                    "description": "Zahel is <a target='_blank' href='https://coppermind.net/wiki/Vasher'>Vasher</a>. <a target='_blank' href='https://coppermind.net/wiki/Szeth'>Szeth</a>'s new <a target='_blank' href='https://coppermind.net/wiki/Shardblade'>Shardblade</a> is <a target='_blank' href='https://coppermind.net/wiki/Nightblood'>Nightblood</a>. <a target='_blank' href='https://coppermind.net/wiki/Mraize'>Mraize</a>'s collection in <a target='_blank' href='https://coppermind.net/wiki/Summary:Words_of_Radiance#Chapter_43:_The_Ghostbloods'>Chapter 43</a> includes a <a target='_blank' href='https://coppermind.net/wiki/Tears_of_Edgli'>Tear of Edgli</a> flower."
-                                },
-                                {
-                                    "target": "sa3",
-                                    "type": "major",
-                                    "description": "Azure is <a target='_blank' href='https://coppermind.net/wiki/Vivenna'>Vivenna</a>; she uses <a target='_blank' href='https://coppermind.net/wiki/Awakening'>Awakening</a> on several occaisions and has an Awakened sword. <a target='_blank' href='https://coppermind.net/wiki/Nightblood'>Nightblood</a> and <a target='_blank' href='https://coppermind.net/wiki/Vasher'>Vasher</a> make significant appearances. <a target='_blank' href='https://coppermind.net/wiki/Nightblood'>Nightblood</a> mentions <a target='_blank' href='https://coppermind.net/wiki/Denth'>Denth</a>, <a target='_blank' href='https://coppermind.net/wiki/Shashara'>Shashara</a>, and <a target='_blank' href='https://coppermind.net/wiki/Vivenna'>Vivenna</a> by name. A painting from the <a target='_blank' href='https://coppermind.net/wiki/Court_of_Gods'>Court of Gods</a> appears in <a target='_blank' href='https://coppermind.net/wiki/Summary:Oathbringer#Chapter_102:_Celebrant'>Chapter 102</a>. <a target='_blank' href='https://coppermind.net/wiki/Riino'>Riino</a> mentions <a target='_blank' href='https://coppermind.net/wiki/Heightening'>Heightenings</a>. <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> uses <a target='_blank' href='https://coppermind.net/wiki/Awakening'>Awakening</a> in the <a target='_blank' href='https://coppermind.net/wiki/Summary:Oathbringer#Epilogue:_Great_Art'>Epilogue</a>."
-                                },
-								{
-                                    "target": "sa3.5",
-                                    "type": "minor",
-                                    "description": "The <a target='_blank' href='https://coppermind.net/wiki/Dawnshard'>Dawnshard</a> causes <a target='_blank' href='https://coppermind.net/wiki/Rysn_Ftori'>Rysn</a> to experience several effects similar to the <a target='_blank' href='https://coppermind.net/wiki/BioChromatic_Breath'>Heightenings associated with Breath</a>."
-                                },
-								{
-                                    "target": "sa4",
-                                    "type": "major",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Nightblood'>Nightblood</a> is used to kill <a target='_blank' href='https://coppermind.net/wiki/Rayse'>Rayse</a>. <a target='_blank' href='https://coppermind.net/wiki/Ialai'>Ialai's</a> notes mention <a target='_blank' href='https://coppermind.net/wiki/Nalthis'>Nalthis</a>. <a target='_blank' href='https://coppermind.net/wiki/Zahel'>Zahel</a> uses <a target='_blank' href='https://coppermind.net/wiki/Awakening'>Awakening</a> in his fight against <a target='_blank' href='https://coppermind.net/wiki/Kaladin'>Kaladin</a> and explains that he is a <a target='_blank' href='https://coppermind.net/wiki/Cognitive_Shadow'>Cognitive Shadow</a>. The coin <a target='_blank' href='https://coppermind.net/wiki/Adolin'>Adolin</a> gives to <a target='_blank' href='https://coppermind.net/wiki/Kaladin'>Kaladin</a> and some merchants in <a target='_blank' href='https://coppermind.net/wiki/Lasting_Integrity'>Lasting Integrity</a> are from <a target='_blank' href='https://coppermind.net/wiki/Nalthis'>Nalthis</a>. <a target='_blank' href='https://coppermind.net/wiki/Endowment'>Endowment</a> is referenced in the <a target='_blank' href='https://coppermind.net/wiki/Rhythm_of_War/Epigraphs'>Chapter 24 epigraph</a>. <a target='_blank' href='https://coppermind.net/wiki/Odium'>Odium</a> tampers with <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid's</a> <a target='_blank' href='https://coppermind.net/wiki/BioChromatic_Breath'>Breath</a> in the Epilogue."
-                                },
-				{
-				    "target": "mb7",
-				    "type": "significant",
-				    "description": "WIP"
-				}
-                            ]
-                        },
-                        {
-                            "id": "nb",
-                            "title": "Nightblood",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Nightblood_(book)'>Nightblood</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Nalthis'>Nalthis</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Nalthian_system'>Nalthian system</a>",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/87/#e5657'>This sequel occurs prior to The Stormlight Archive.</a>",
-                            "sorting": {
-                                "chronology": 5.2
-                            },
-                            "categories": [ "warbreaker", "plan", "unpublished", "novel" ]
-                        }
-                    ]
-                }
-            ]
-        },
-        {
-            "label": "Roshar",
-            "color": "#2aa1d4",
-            "children": [
-                {
-                    "label": "The Stormlight Archive",
-                    "children": [
-                        {
-                            "id": "sa1",
-                            "title": "The Way of Kings",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Way_of_Kings'>The Way of Kings</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-                            "publication": "August 2010",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/309/#e10273'>Occurs after Mistborn Era 1 and Warbreaker but before Mistborn Era 2.</a>",
-                            "sorting": {
-				"order": 2.41,
-                                "publication": 2010.08,
-                                "chronology": 7.01
-                            },
-                            "appearances": [
-                                {
-                                    "id": "hoid",
-                                    "type": "appearance",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is 'Wit'."
-                                },
-                                {
-                                    "id": "ars",
-                                    "type": "appearance"
-                                }
-                            ],
-                            "categories": [ "stormlight", "phase2", "published", "novel" ]
-                        },
-                        {
-                            "id": "sa2",
-                            "title": "Words of Radiance",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Words_of_Radiance'>Words of Radiance</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-                            "publication": "March 2014",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/309/#e10273'>Occurs after Mistborn Era 1 and Warbreaker but before Mistborn Era 2.</a>",
-                            "sorting": {
-				"order": 2.42,
-                                "publication": 2014.03,
-                                "chronology": 7.02
-                            },
-                            "appearances": [
-                                {
-                                    "id": "hoid",
-                                    "type": "appearance",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is 'Wit'."
-                                },
-                                {
-                                    "id": "nazh",
-                                    "type": "appearance",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> is the <a target='_blank' href='https://coppermind.net/wiki/Ardent'>ardent</a> trying to get a sketch of <a target='_blank' href='https://coppermind.net/wiki/Bridge_Four'>Bridge Four</a>'s tattoo in <a target='_blank' href='https://coppermind.net/wiki/Summary:Words_of_Radiance#Chapter_31:_The_Stillness_Before'>Chapter 31</a>. Several drawings and sketches also include his annotations."
-                                },
-                                {
-                                    "id": "ars",
-                                    "type": "appearance"
-                                }
-                            ],
-                            "categories": [ "stormlight", "phase2", "published", "novel" ],
-                            "connections": [
-                                {
-                                    "target": "jasnah",
-                                    "type": "major",
-                                    "description": "A deleted scene about <a target='_blank' href='https://coppermind.net/wiki/Jasnah_Kholin'>Jasnah</a> that contains some canonical elements."
-                                },
-                                {
-                                    "target": "traveler",
-                                    "type": "minor",
-                                    "description": "The man <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> speaks with is <a target='_blank' href='https://coppermind.net/wiki/Frost'>Frost</a>, who responded to <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> with similar opinions in the <a target='_blank' href='https://coppermind.net/wiki/Words_of_Radiance/Epigraphs#The_Second_Letter'>Words of Radiance Part 4 epigraphs</a>."
-                                },
-                                {
-                                    "target": "au",
-                                    "type": "minor",
-                                    "description": "The <a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a> essay covers details about <a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a> and makes mentions of <a target='_blank' href='https://coppermind.net/wiki/Odium'>Odium</a>'s past."
-                                },
-				{
-				    "target": "mb7",
-				    "type": "minor",
-				    "description": "WIP"
-				}
-                            ]
-                        },
-                        {
-                            "id": "sa2.5",
-                            "title": "Edgedancer",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Edgedancer'>Edgedancer</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-                            "au": "Included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
-                            "padding": 12,
-                            "publication": "November 2016",
-                            "chronology": "Occurs after Words of Radiance and concurrently with the early events of Oathbringer.",
-                            "sorting": {
-				"order": 2.43,
-                                "publication": 2016.11,
-                                "chronology": 7.025
-                            },
-                            "appearances": [
-                                {
-                                    "id": "hoid",
-                                    "type": "mention",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is 'Ol' Whitehair', mentioned in <a target='_blank' href='https://coppermind.net/wiki/Summary:Edgedancer#Chapter_12'>Chapter 12</a>."
-                                }
-                            ],
-                            "categories": [ "stormlight", "novella", "phase2", "published" ]
-                        },
-                        {
-                            "id": "sa3",
-                            "title": "Oathbringer",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Oathbringer'>Oathbringer</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-                            "publication": "November 2017",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/309/#e10273'>Occurs after Mistborn Era 1 and Warbreaker but before Mistborn Era 2.</a>",
-                            "sorting": {
-				"order": 2.44,
-                                "publication": 2017.11,
-                                "chronology": 7.03
-                            },
-                            "appearances": [
-                                {
-                                    "id": "hoid",
-                                    "type": "appearance",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is 'Wit'."
-                                },
-                                {
-                                    "id": "nazh",
-                                    "type": "mention",
-                                    "description": "Several drawings and sketches include <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a>'s annotations. Most notably, the <a target='_blank' href='https://coppermind.net/wiki/Glyphs'>glyphs</a> page is entirely written by him."
-                                },
-                                {
-                                    "id": "ars",
-                                    "type": "appearance"
-                                }
-                            ],
-                            "categories": [ "stormlight", "phase2", "published", "novel" ],
-                            "connections": [
-                                {
-                                    "target": "twokp",
-                                    "type": "minor",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/The_Way_of_Kings_Prime'>The Way of Kings Prime</a>, written in 2002, is the original draft of <a target='_blank' href='https://coppermind.net/wiki/The_Way_of_Kings'>The Way of Kings</a>. Only small excerpts were released prior to <a target='_blank' href='https://coppermind.net/wiki/The_Way_of_Kings'>Oathbringer</a> as Brandon felt it contained spoilers for certain ideas through that book. It was self-published as a Sanderson Curiosity in July 2020."
-                                },
-				{
-				    "target": "mb7",
-				    "type": "minor",
-				    "description": "WIP"
-				}
-                            ]
-                        },
-                        {
-                            "id": "sa3.5",
-                            "title": "Dawnshard",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Dawnshard_(novella)'>Dawnshard</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-                            "publication": "November 2020",
-			    "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/406/#e13986'>Between Oathbringer and Rhythm of War.</a>",
-                            "padding": 12,
-                            "sorting": {
-				"order": 2.45,
-                                "publication": 2020.1105,
-                                "chronology": 7.035
-                            },
-                            "categories": [ "stormlight", "novella", "published", "phase2" ]
-                        },
-                        {
-                            "id": "sa4",
-                            "title": "Rhythm of War",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Rhythm_of_War'>Rhythm of War</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-                            "publication": "November 2020",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/309/#e10273'>Occurs after Mistborn Era 1 and Warbreaker but before Mistborn Era 2.</a>",
-                            "sorting": {
-				"order": 2.46,
-                                "publication": 2020.1117,
-                                "chronology": 7.04
-                            },
-                            "appearances": [
-                                {
-                                    "id": "hoid",
-                                    "type": "appearance",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is 'Wit'."
-                                },
-                                {
-                                    "id": "nazh",
-                                    "type": "mention",
-                                    "description": "Several drawings and sketches include <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a>'s annotations. Most notably, the <a target='_blank' href='https://coppermind.net/wiki/Glyphs'>glyphs</a> page is entirely written by him."
-                                },
-                                {
-                                    "id": "ars",
-                                    "type": "appearance"
-                                }
-                            ],
-                            "categories": [ "stormlight", "novel", "phase2", "published" ],
-                            "connections": [
-                                {
-                                    "target": "d1",
-                                    "type": "egg",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Microkinesis'>Microkinesis</a> referes to a type of magic from <a target='_blank' href='https://coppermind.net/wiki/Yolen'>Yolen</a> in <a target='_blank' href='https://coppermind.net/wiki/Dragonsteel'>Dragonsteel</a>."
-                                },
-                                {
-                                    "target": "mb2",
-                                    "type": "minor",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Ati'>Ati</a> speaks to <a target='_blank' href='https://coppermind.net/wiki/Vin'>Vin</a> and others with <a target='_blank' href='https://coppermind.net/wiki/Ruin'>Ruin's</a> <a target='_blank' href='https://coppermind.net/wiki/Rhythm#The_Pure_Tones'>Pure Tone</a>. The <a target='_blank' href='https://coppermind.net/wiki/Well_of_Ascension'>Well of Ascension</a> pulses with <a target='_blank' href='https://coppermind.net/wiki/Preservation'>Preservation's</a> <a target='_blank' href='https://coppermind.net/wiki/Rhythm#The_Pure_Tones'>Pure Tone</a>"
-                                },
-				{
-				    "target": "mb7",
-				    "type": "significant",
-				    "description": "WIP"
-				}
-                            ]
-                        },
-                        {
-                            "id": "sa4.5",
-                            "title": "Horneater (2023)",
-                            "title2": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2019/'>Horneater</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-                            "padding": 12,
-                            "chronology": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>Fills in what happened with Rock after the events of Rhythm of War.</a>",
-                            "sorting": {
-                                "publication": 2023.11,
-				"chronology": 7.045
-                            },
-                            "categories": [ "stormlight", "novella", "plan", "unpublished" ]
-                        },
-                        {
-                            "id": "sa5",
-                            "title": "Stormlight Archive 5 (2024)",
-                            "title2": "Stormlight Archive 5",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-                            "publication": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>Fall 2023</a>",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/309/#e10273'>Occurs after Mistborn Era 1 and Warbreaker but before Mistborn Era 2.</a>",
-                            "sorting": {
-				"publication": 2023.11,
-                                "chronology": 7.05
-                            },
-                            "categories": [ "stormlight", "plan", "forthcoming", "novel" ]
-                        },
-                        {
-                            "id": "lopen",
-                            "title": "King Lopen the First",
-                            "title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=king+lopen+the+first+of+alethkar'>King Lopen the First of Alethkar</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/31/#e1703'>Occurs concurrently with the final events of Words of Radiance.</a>",
-                            "padding": 12,
-                            "sorting": {
-                                "chronology": 7.022
-                            },
-                            "categories": [ "stormlight", "short", "plan", "unpublished" ]
-                        },
-                        {
-                            "id": "tdatd",
-                            "title": "The Dog and the Dragon",
-                            "title2": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>The Dog and the Dragon picture book</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-                            "padding": 12,
-                            "categories": [ "stormlight", "plan", "unpublished", "graphic" ]
-                        },
-                        {
-                            "id": "tgwlu",
-                            "title": "The Girl Who Looked Up",
-                            "title2": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>The Girl Who Looked Up picture book</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-                            "padding": 12,
-                            "categories": [ "stormlight", "plan", "unpublished", "graphic" ]
-                        },
-                        {
-                            "id": "sa-art",
-                            "title": "Stormlight Archive art book",
-                            "title2": "<a target='_blank' href='https://wob.coppermind.net/events/396/#e13175'>Stormlight Archive art book</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-                            "padding": 12,
-                            "categories": [ "stormlight", "plan", "unpublished", "graphic" ]
-                        },
-                        {
-                            "id": "sa6",
-                            "title": "Stormlight Archive 6",
-                            "title2": "Stormlight Archive 6",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/61/#e1300'>There's a roughly 15 year gap between Stormlight 5 and 6.</a> <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>Occurs after Mistborn Era 2 and before Mistborn Era 3.</a>",
-                            "publication": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>2028 (best guess)</a>",
-                            "sorting": {
-                                "chronology": 9.06,
-				"publication": 2028
-                            },
-                            "categories": [ "stormlight", "plan", "unpublished", "novel" ]
-                        },
-                        {
-                            "id": "sa7",
-                            "title": "Stormlight Archive 7",
-                            "title2": "Stormlight Archive 7",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/61/#e1300'>There's a roughly 15 year gap between Stormlight 5 and 6.</a> <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>Occurs after Mistborn Era 2 and before Mistborn Era 3.</a>",
-                            "sorting": {
-                                "chronology": 9.07
-                            },
-                            "categories": [ "stormlight", "plan", "unpublished", "novel" ]
-                        },
-                        {
-                            "id": "sa8",
-                            "title": "Stormlight Archive 8",
-                            "title2": "Stormlight Archive 8",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/61/#e1300'>There's a roughly 15 year gap between Stormlight 5 and 6.</a> <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>Occurs after Mistborn Era 2 and before Mistborn Era 3.</a>",
-                            "sorting": {
-                                "chronology": 9.08
-                            },
-                            "categories": [ "stormlight", "plan", "unpublished", "novel" ]
-                        },
-                        {
-                            "id": "sa9",
-                            "title": "Stormlight Archive 9",
-                            "title2": "Stormlight Archive 9",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/61/#e1300'>There's a roughly 15 year gap between Stormlight 5 and 6.</a> <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>Occurs after Mistborn Era 2 and before Mistborn Era 3.</a>",
-                            "sorting": {
-                                "chronology": 9.09
-                            },
-                            "categories": [ "stormlight", "plan", "unpublished", "novel" ]
-                        },
-                        {
-                            "id": "sa10",
-                            "title": "Stormlight Archive 10",
-                            "title2": "Stormlight Archive 10",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/61/#e1300'>There's a roughly 15 year gap between Stormlight 5 and 6.</a> <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>Occurs after Mistborn Era 2 and before Mistborn Era 3.</a>",
-                            "sorting": {
-                                "chronology": 9.10
-                            },
-                            "categories": [ "stormlight", "plan", "unpublished", "novel" ],
-                            "connections": [
-                                {
-                                    "target": "sotd2",
-                                    "type": "minor",
-                                    "description": "A <a target='_blank' href='https://coppermind.net/wiki/Knights_Radiant'>Knight Radiant</a> makes an appearance, weilding a 'Shardgun'."
-                                }
-                            ]
-                        }
-                    ]
-                },
-				{
-					"children": [
-                        {
-                            "id": "tsd",
-                            "title": "The Silence Divine",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Silence_Divine'>The Silence Divine</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Ashyn'>Ashyn</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-                            "link": "<a target='_blank' href='https://wob.coppermind.net/events/201/#e12303'>Excerpt on Arcanum.</a>",
-                            "publication": "March 2014",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/370/#e11901'>Occurs late in the Stormlight Archive era, around book 8.</a>",
-                            "sorting": {
-                                "publication": 2014.03,
-                                "chronology": 9.081
-                            },
-                            "categories": [ "no-series", "plan", "unpublished", "novella" ],
-                            "connections": [
-                                {
-                                    "target": "sa3",
-                                    "type": "minor",
-                                    "description": "The Silence Divine is set on <a target='_blank' href='https://coppermind.net/wiki/Ashyn'>Ashyn</a>, the world that the humans fled to <a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a> from."
-                                }
-                            ]
-                        }
-		    ]
-		}
-            ]
-        },
-        {
-            "label": "Taldain",
-            "color": "#d4c955",
-            "children": [
-                {
-                    "label": "White Sand",
-                    "children": [
-                        {
-                            "id": "ws1",
-                            "title": "White Sand Volume 1",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/White_Sand_Volume_1'>White Sand Volume 1</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/White_Sand'>White Sand</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Taldain_system'>Taldain system</a>",
-                            "au": "Excerpt included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
-                            "publication": "June 2016",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/182/#e3878'>White Sand occurs prior to Elantris.</a>",
-                            "sorting": {
-				"order": 2.11,
-                                "publication": 2016.06,
-                                "chronology": 2.1
-                            },
-                            "appearances": [
-                                {
-                                    "id": "hoid",
-                                    "type": "appearance",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is the hooded man with a stringed instrument who first appears in <a target='_blank' href='https://coppermind.net/wiki/Ais'>Ais</a>'s first scene in the middle of <a target='_blank' href='https://coppermind.net/wiki/Summary:White_Sand_Volume_1#Chapter_4:_Divides'>Chapter 4</a>."
-                                },
-                                {
-                                    "id": "khriss",
-                                    "type": "appearance",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> is a main character."
-                                }
-                            ],
-                            "categories": [ "white-sand", "phase2b", "published", "graphic" ],
-                            "connections": [
-                                {
-                                    "target": "mb1",
-                                    "type": "egg",
-                                    "description": "'Kenton Street' in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Well_of_Ascension#Chapter_17'>Chapter 17</a> (also mentioned in <a target='_blank' href='https://coppermind.net/wiki/The_Well_of_Ascension'>The Well of Ascension) is a reference to <a target='_blank' href='https://coppermind.net/wiki/Kenton'>Kenton</a>."
-                                },
-                                {
-                                    "target": "sa2",
-                                    "type": "egg",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Mraize'>Mraize</a>'s collection in <a target='_blank' href='https://coppermind.net/wiki/Summary:Words_of_Radiance#Chapter_43:_The_Ghostbloods'>Chapter 43</a> includes a vial of sand from <a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a>."
-                                },
-                                {
-                                    "target": "au",
-                                    "type": "minor",
-                                    "description": "The <a target='_blank' href='https://coppermind.net/wiki/Taldain_system'>Taldain system</a> essay discusses <a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a> and <a target='_blank' href='https://coppermind.net/wiki/Sand_mastery'>sand mastery</a>."
-                                },
-                                {
-                                    "target": "sa4",
-                                    "type": "minor",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a> is referenced in <a target='_blank' href='https://coppermind.net/wiki/Ialai'>Ialai's</a> notes."
-                                },
-				{
-				    "target": "mb7",
-				    "type": "minor",
-				    "description": "WIP"
-				}
-                            ]
-                        },
-                        {
-                            "id": "ws2",
-                            "title": "White Sand Volume 2",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/White_Sand_Volume 2'>White Sand Volume 2</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/White_Sand'>White Sand</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Taldain_system'>Taldain system</a>",
-                            "publication": "February 2018",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/182/#e3878'>White Sand occurs prior to Elantris.</a>",
-                            "sorting": {
-				"order": 2.12,
-                                "publication": 2018.02,
-                                "chronology": 2.2
-                            },
-                            "appearances": [
-                                {
-                                    "id": "hoid",
-                                    "type": "appearance",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is the hooded man with a stringed instrument."
-                                },
-                                {
-                                    "id": "khriss",
-                                    "type": "appearance",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> is a main character."
-                                }
-                            ],
-                            "categories": [ "white-sand", "phase2b", "published", "graphic" ],
-                            "connections": [
-                                {
-                                    "target": "mb1",
-                                    "type": "minor",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Trell_(Taldain)'>Trell the foreman</a> is connected to <a target='_blank' href='https://coppermind.net/wiki/Trelagism'>Trelagism</a>."
-                                },
-                                {
-                                    "target": "mb4",
-                                    "type": "significant",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Trell_(Taldain)'>Trell the foreman</a> is connected to the god <a target='_blank' href='https://coppermind.net/wiki/Trellism'>Trell</a>."
-                                },
-                                {
-                                    "target": "sa3",
-                                    "type": "egg",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Wit</a> has a jar of black sand from <a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a> in <a target='_blank' href='https://coppermind.net/wiki/Summary:Oathbringer#Chapter_67:_Mishim'>Chapter 67</a>, which turns white after <a target='_blank' href='https://coppermind.net/wiki/Shallan'>Shallan</a> <a target='_blank' href='https://coppermind.net/wiki/Lightweaving'>Lightweaves</a>."
-                                },
-                                {
-                                    "target": "sa4",
-                                    "type": "minor",
-                                    "description": "Sand from <a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a> is used to identify and quantify <a target='_blank' href='https://coppermind.net/wiki/Investiture'>kinetic Investiture</a>, including explicit mention of the fauna which makes the sand special."
-                                }
-                            ]
-                        },
-                        {
-                            "id": "ws3",
-                            "title": "White Sand Volume 3",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/White_Sand_Volume_3'>White Sand Volume 3</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/White_Sand'>White Sand</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Taldain_system'>Taldain system</a>",
-                            "publication": "October 2019",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/182/#e3878'>White Sand occurs prior to Elantris.</a>",
-                            "sorting": {
-				"order": 2.13,
-                                "publication": 2019.10,
-                                "chronology": 2.3
-                            },
-                            "appearances": [
-                                {
-                                    "id": "hoid",
-                                    "type": "appearance",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is the hooded man with a stringed instrument who plays a song in the <a target='_blank' href='https://coppermind.net/wiki/Summary:White_Sand_Volume_3#Epilogue'>Epilogue</a>."
-                                },
-                                {
-                                    "id": "khriss",
-                                    "type": "appearance",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> is a main character."
-                                }
-                            ],
-                            "categories": [ "white-sand", "phase2b", "published", "graphic" ],
-                            "connections": [
-                                {
-                                    "target": "sa1",
-                                    "type": "egg",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Baon'>Baon</a> appears in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Way_of_Kings#Interlude_I-1:_Ishikk'>Interlude I-1</a> as 'Blunt'."
-                                }
-                            ]
-                        }
-                    ]
-                },
+	"base-separation": 3.21,
+	"connections": [
 		{
-                    "label": "The Arcanist",
-                    "children": [
-                        {
-                            "id": "ta1",
-                            "title": "The Arcanist Volume 1",
-                            "title2": "The Arcanist Volume 1",
-                            "series": "The Arcanist (citation needed)",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Taldain_system'>Taldain system</a>",
-                            "chronology": "Described as a sequel, so presumably occurs shortly after White Sand.",
-                            "sorting": {
-                                "chronology": 2.5
-                            },
-                            "categories": [ "white-sand", "plan", "unpublished", "graphic" ]
-                        },
-                        {
-                            "id": "ta2",
-                            "title": "The Arcanist Volume 2",
-                            "title2": "The Arcanist Volume 2",
-                            "series": "The Arcanist (citation needed)",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Taldain_system'>Taldain system</a>",
-                            "chronology": "Described as a sequel, so presumably occurs shortly after White Sand.",
-                            "sorting": {
-                                "chronology": 2.6
-                            },
-                            "categories": [ "white-sand", "plan", "unpublished", "graphic" ]
-                        },
-                        {
-                            "id": "ta3",
-                            "title": "The Arcanist Volume 3",
-                            "title2": "The Arcanist Volume 3",
-                            "series": "The Arcanist (citation needed)",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Taldain_system'>Taldain system</a>",
-                            "chronology": "Described as a sequel, so presumably occurs shortly after White Sand.",
-                            "sorting": {
-                                "chronology": 2.7
-                            },
-                            "categories": [ "white-sand", "plan", "unpublished", "graphic" ]
-                        }
-                    ]
-                }
-            ]
-        },
-        {
-            "label": "Threnody",
-            "color": "#6633cc",
-            "children": [
-                {
-                    "children": [
-                        {
-                            "id": "sfs",
-                            "title": "Shadows for Silence",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Shadows_for_Silence_in_the_Forests_of_Hell'>Shadows for Silence in the Forests of Hell</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Threnody'>Threnody</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Threnodite_system'>Threnodite system</a>",
-                            "au": "Included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
-                            "publication": "December 2013",
-                            "chronology": "Occurs <a target='_blank' href='https://wob.coppermind.net/events/216/#e6445'>before Stormlight Archive</a> but <a target='_blank' href='https://wob.coppermind.net/events/309/#e10273'>after Warbreaker</a>.",
-                            "sorting": {
-				"order": 1.5,
-                                "publication": 2013.12,
-                                "chronology": 6.1
-                            },
-                            "categories": [ "no-series", "novella", "phase1b", "published" ],
-                            "connections": [
-                                {
-                                    "target": "sa2",
-                                    "type": "egg",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Mraize'>Mraize</a>'s collection in <a target='_blank' href='https://coppermind.net/wiki/Summary:Words_of_Radiance#Chapter_43:_The_Ghostbloods'>Chapter 43</a> includes a silver knife from <a target='_blank' href='https://coppermind.net/wiki/Threnody'>Threnody</a>."
-                                },
-                                {
-                                    "target": "sa3",
-                                    "type": "egg",
-                                    "description": "The silvery chain in <a target='_blank' href='https://coppermind.net/wiki/Celebrant'>Celebrant</a> is from <a target='_blank' href='https://coppermind.net/wiki/Threnody'>Threnody</a>."
-                                },
-                                {
-                                    "target": "msh",
-                                    "type": "minor",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Kelsier'>Kelsier</a> causes the <a target='_blank' href='https://coppermind.net/wiki/Ire'>Ire</a> to suspect <a target='_blank' href='https://coppermind.net/wiki/Shade'>Shades</a> from <a target='_blank' href='https://coppermind.net/wiki/Threnody'>Threnody</a> are nearby."
-                                },
-                                {
-                                    "target": "au",
-                                    "type": "minor",
-                                    "description": "The <a target='_blank' href='https://coppermind.net/wiki/Threnodite_system'>Threnodite system</a> essay discusses the history of <a target='_blank' href='https://coppermind.net/wiki/Threnody'>Threnody</a>."
-                                },
-                                {
-                                    "target": "sa4",
-                                    "type": "egg",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Raboniel'>Raboniel's</a> chain from 'the lands of the dead' is likely a <a target='_blank' href='https://coppermind.net/wiki/Silver'>silver</a> chain from <a target='_blank' href='https://coppermind.net/wiki/Threnody'>Threnody</a>."
-                                }
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "children": [
-                        {
-                            "id": "db",
-                            "title": "The Dust Brigade",
-                            "title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=the+dust+brigade'>The Dust Brigade</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Threnody'>Threnody</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Threnodite_system'>Threnodite system</a>",
-                            "categories": [ "no-series", "plan", "unpublished", "novel" ]
-                        }
-                    ]
-                }
-            ]
-        },
-        {
-            "label": "First of<br>the Sun",
-            "color": "#367485",
-            "children": [
-                {
-                    "children": [
-                        {
-                            "id": "sotd",
-                            "title": "Sixth of the Dusk",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Sixth_of_the_Dusk'>Sixth of the Dusk</a>",
-                            "series": "Sixth of<br>the Dusk",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/First_of_the_Sun'>First of the Sun</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Drominad_system'>Drominad system</a>",
-                            "au": "Included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
-                            "publication": "June 2014",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/60/#e6664'>Shortly before Mistborn Era 4.</a>",
-                            "sorting": {
-				"order": 1.6,
-                                "publication": 2014.06,
-                                "chronology": 13.0
-                            },
-                            "categories": [ "no-series", "novella", "phase1b", "published" ],
-                            "connections": [
-                                {
-                                    "target": "sa3",
-                                    "type": "minor",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Mraize'>Mraize</a>'s chicken, mentioned in <a target='_blank' href='https://coppermind.net/wiki/Summary:Oathbringer#Chapter_22:_The_Darkness_Within'>Chapter 22</a>, is an <a target='_blank' href='https://coppermind.net/wiki/Aviar'>Aviar</a>. <a target='_blank' href='https://coppermind.net/wiki/Patji'>Patji</a> is referenced obliquely in <a target='_blank' href='https://coppermind.net/wiki/Autonomy'>Autonomy</a>'s <a target='_blank' href='https://coppermind.net/wiki/Letters#Second_Oathbringer_Letter'>letter</a> to <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> in the <a target='_blank' href='https://coppermind.net/wiki/Oathbringer/Epigraphs#Letters'>Part 2 epigraphs</a>."
-                                },
-                                {
-                                    "target": "au",
-                                    "type": "minor",
-                                    "description": "The <a target='_blank' href='https://coppermind.net/wiki/Drominad_system'>Drominad system</a> essay discusses <a target='_blank' href='https://coppermind.net/wiki/First_of_the_Sun'>First of the Sun</a> and its magic."
-                                },
-                                {
-                                    "target": "sa4",
-                                    "type": "minor",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Gereh'>Gereh</a> has an <a target='_blank' href='https://coppermind.net/wiki/Aviar'>Aviar</a>, which <a target='_blank' href='https://coppermind.net/wiki/Lift'>Lift</a> comes into possession of."
-                                }
-                            ]
-                        },
-                        {
-                            "id": "sotd2",
-                            "title": "Sixth of the Dusk sequel",
-                            "title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=sixth+of+the+dusk+sequel'>Sixth of the Dusk sequel</a>",
-                            "series": "Sixth of<br>the Dusk",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/First_of_the_Sun'>First of the Sun</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Drominad_system'>Drominad system</a>",
-                            "chronology": "Five years after Sixth of the Dusk.",
-                            "sorting": {
-                                "chronology": 13.02
-                            },
-                            "link": "<a target='_blank' href='https://wob.coppermind.net/events/448/#e14408'>Excerpt on Arcanum.</a> (some may consider to be spoilers)",
-                            "categories": [ "no-series", "novella", "plan", "unpublished" ]
-                        }
-                    ]
-                },
-                {
-                    "children": [
-                        {
-                            "id": "kingmaker",
-                            "title": "Kingmaker",
-                            "title2": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>Kingmaker</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/First_of_the_Sun'>First of the Sun</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Drominad_system'>Drominad system</a>",
-                            "link": "<a target='_blank' href='https://wob.coppermind.net/events/479/#e15153'>Reading on Arcanum.</a>",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/479/#e15153'>The reading suggests a setting not long after Sixth of the Dusk.</a>",
-                            "sorting": {
-                                "chronology": 13.01
-                            },
-                            "categories": [ "no-series", "novel", "plan", "unpublished" ]
-                        }
-				    ]
-                }
-            ]
-        },
-        {
-            "label": "Yolen",
-            "color": "#d98a41",
-            "children": [
-                {
-                    "label": "Dragonsteel",
-                    "children": [
-                        {
-                            "id": "d1",
-                            "title": "Dragonsteel 1",
-                            "title2": "Dragonsteel 1",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Dragonsteel'>Dragonsteel</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Yolen'>Yolen</a>",
-                            "system": "Yolish system",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/103/#e1024'>Dragonsteel is the first series in the cosmere storyline.</a>",
-                            "sorting": {
-                                "chronology": 1.1
-                            },
-                            "categories": [ "dragonsteel", "plan", "unpublished", "novel" ],
-			    "connections": [
+			"id": "major",
+			"description": "Major Connections",
+			"details": "There is at least one major connection between the books which will enhance your understanding of the plot and the Cosmere. Reading in this order is highly recommended, and reading out of order may be spoilery.",
+			"color": "#770000",
+			"highlightColor": "#DB1E1E",
+			"width": 2
+		},
+		{
+			"id": "significant",
+			"description": "Significant Connections",
+			"details": "There is at least one significant connection between the books which may enhance your understanding of the plot and the Cosmere. Reading in this order is recommended.",
+			"color": "#a0470d",
+			"highlightColor": "#a0470d",
+			"width": 2,
+			"dash": "4 2"
+		},
+		{
+			"id": "minor",
+			"description": "Minor Connections",
+			"details": "There is at least one minor connection between the books which may enhance your understanding of the plot and Cosmere in a small way.",
+			"color": "#a09713",
+			"highlightColor": "#a09713",
+			"width": 1,
+			"dash": "3",
+			"activeByDefault": false
+		},
+		{
+			"id": "egg",
+			"description": "Easter Eggs",
+			"details": "There is at least one subtle reference between the books which may hint at something bigger going on. Easter eggs may be very difficult to spot unaided.",
+			"color": "#4d4d4d",
+			"highlightColor": "#4d4d4d",
+			"width": 1,
+			"dash": "2",
+			"activeByDefault": false
+		}
+	],
+	"layers": [
+		{
+			"id": "pub-status",
+			"name": "Publication Status",
+			"categories": [
 				{
-				    "target": "mb7",
-				    "type": "egg",
-				    "description": "WIP"
+					"id": "published",
+					"description": "Published",
+					"details": "Published, canonical works.",
+					"color": "#FFFFFF"
+				},
+				{
+					"id": "forthcoming",
+					"description": "Forthcoming",
+					"details": "Forthcoming works with a planned release month or which are being actively worked on. Expected publication dates may be in parenthesis. Titles may be tentative.",
+					"color": "#888888"
+				},
+				{
+					"id": "unpublished",
+					"description": "Future Plans",
+					"details": "Includes all planned future cosmere stories. Likelihood of publication varies. Expected publication dates may be in parenthesis. Titles are tentative.",
+					"color": "#505050"
+				},
+				{
+					"id": "noncanon",
+					"description": "Other",
+					"details": "Uncanonical works which are publicly available, both excerpts and complete.",
+					"color": "#735a45"
 				}
 			]
-                        },
-                        {
-                            "id": "d2",
-                            "title": "Dragonsteel 2",
-                            "title2": "Dragonsteel 2",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Dragonsteel'>Dragonsteel</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Yolen'>Yolen</a>",
-                            "system": "Yolish system",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/103/#e1024'>Dragonsteel is the first series in the cosmere storyline.</a>",
-                            "sorting": {
-                                "chronology": 1.2
-                            },
-                            "categories": [ "dragonsteel", "plan", "unpublished", "novel" ]
-                        },
-                        {
-                            "id": "d3",
-                            "title": "Dragonsteel 3",
-                            "title2": "Dragonsteel 3",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Dragonsteel'>Dragonsteel</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Yolen'>Yolen</a>",
-                            "system": "Yolish system",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/103/#e1024'>Dragonsteel is the first series in the cosmere storyline.</a>",
-                            "sorting": {
-                                "chronology": 1.3
-                            },
-                            "categories": [ "dragonsteel", "plan", "unpublished", "novel" ]
-                        }
-                    ]
-                }
-            ]
-        },
-        {
-            "label": "Other",
-            "color": "#a0a0a0",
-            "children": [
-                {
-                    "label": "Aether<br>Series",
-		    "color": "#e3a1e3",
-		    "children": [
-                        {
-                            "id": "aether1",
-                            "title": "Aether Book 1",
-                            "title2": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2019/'>Aether Book 1</a>",
-                            "world": "Unknown",
-                            "system": "Unknown",
-                            "categories": [ "aether", "novel", "plan", "unpublished" ]
-                        },
-                        {
-                            "id": "aether2",
-                            "title": "Aether Book 2",
-                            "title2": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2019/'>Aether Book 2</a>",
-                            "world": "Unknown",
-                            "system": "Unknown",
-                            "categories": [ "aether", "novel", "plan", "unpublished" ]
-                        },
-                        {
-                            "id": "aether3",
-                            "title": "Aether Book 3",
-                            "title2": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2019/'>Aether Book 3</a>",
-                            "world": "Unknown",
-                            "system": "Unknown",
-                            "categories": [ "aether", "novel", "plan", "unpublished" ]
-                        }
-                    ]
-                },
-                {
-                    "children": [
-                        {
-                            "id": "secret1",
-                            "title": "Secret Project 1 (2023)",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Secret_Project_One'>Secret Project 1</a>",
-                            "world": "Spoiler",
-                            "system": "Spoiler",
-                            "publication": "January 2023",
-                            "sorting": {
-                                "publication": 2023.01
-                            },
-                            "link": "Chapters 1-5 available on <a target='_blank' href='brandonsanderson.com/first-look-at-secret-project-1'>Brandon's website</a> and <a target='_blank' href='https://youtu.be/bBUVXcIE0E0'>YouTube</a>. (some may consider to be spoilers)",
-                            "categories": [ "no-series", "novel", "plan", "forthcoming" ]
-                        }
-                    ]
-                },
-                {
-                    "children": [
-                        {
-                            "id": "secret3",
-                            "title": "Secret Project 3 (2023)",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Secret_Project_Three'>Secret Project 3</a>",
-                            "world": "Spoiler",
-                            "system": "Spoiler",
-                            "publication": "July 2023",
-                            "sorting": {
-                                "publication": 2023.07
-                            },
-                            "link": "Chapters 1-7 available on <a target='_blank' href='brandonsanderson.com/first-look-at-secret-project-3'>Brandon's website</a> and <a target='_blank' href='https://youtu.be/cFGDcvtRdz0'>YouTube</a>. (some may consider to be spoilers)",
-                            "categories": [ "no-series", "novel", "plan", "forthcoming" ]
-                        }
-                    ]
-                },
-                {
-                    "children": [
-                        {
-                            "id": "secret4",
-                            "title": "Secret Project 4 (2023)",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Secret_Project_Four'>Secret Project 4</a>",
-                            "world": "Spoiler",
-                            "system": "Spoiler",
-                            "publication": "October 2023",
-                            "sorting": {
-                                "publication": 2023.10
-                            },
-                            "categories": [ "no-series", "novel", "plan", "forthcoming" ]
-                        }
-                    ]
-                },
-                {
-                    "children": [
-                        {
-                            "id": "silverlight",
-                            "title": "Silverlight novella",
-                            "title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=silverlight+novella'>Silverlight novella</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Cognitive_Realm'>Cognitive Realm</a>",
-                            "system": "N/A",
-                            "categories": [ "no-series", "novella", "plan", "unpublished" ]
-                        }
-                    ]
-                },
-                {
-                    "children": [
-                        {
-                            "id": "kite",
-                            "title": "Magic Kites YA story",
-                            "title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=kite+magic'>Kite-based magic story</a>",
-                            "world": "Unknown",
-                            "system": "Unknown",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/379/#e12466'>Planned to take place between Mistborn Era 3 and 4.</a>",
-                            "sorting": {
-                                "chronology": 11.0
-                            },
-                            "categories": [ "no-series", "novella", "plan", "unpublished" ]
-                        }
-                    ]
-                },
-                {
-                    "children": [
-                        {
-                            "id": "au",
-                            "title": "Arcanum Unbounded (essays)",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded (essays)</a>",
-                            "world": "N/A",
-                            "system": "N/A",
-                            "au": "Included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
-                            "publication": "November 2016",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/36/#e1491'>The essays were written before the events of Sixth of the Dusk.</a> They could potentially be as early as Mistborn Era 3.",
-                            "sorting": {
-				"order": 2.3,
-                                "publication": 2016.11,
-                                "chronology": 12.0
-                            },
-                            "appearances": [
-                                {
-                                    "id": "khriss",
-                                    "type": "mention",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> is the author of the essays."
-                                }
-                            ],
-                            "categories": [ "no-series", "short", "phase2", "published" ],
-                            "connections": [
-                                {
-                                    "target": "sa4",
-                                    "type": "minor",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Devotion'>Devotion</a> and <a target='_blank' href='https://coppermind.net/wiki/Dominion'>Dominion</a> are referenced in the <a target='_blank' href='https://coppermind.net/wiki/Rhythm_of_War/Epigraphs'>Chapter 26 Epigraph</a>. <a target='_blank' href='https://coppermind.net/wiki/Ambition'>Ambition's</a> struggle with <a target='_blank' href='https://coppermind.net/wiki/Odium'>Odium</a> is referenced in the <a target='_blank' href='https://coppermind.net/wiki/Rhythm_of_War/Epigraphs'>Chapter 27 Epigraph</a>."
-                                },
+		},
+		{
+			"id": "series",
+			"name": "Series",
+			"startActive": true,
+			"categories": [
 				{
-				    "target": "mb7",
-				    "type": "minor",
-				    "description": "WIP"
-				}
-                            ]
-                        }
-                    ]
-                }
-            ]
-        },
-        {
-            "label": "Mixed",
-            "color": "#a0a0a0",
-            "children": [
-                {
-                    "children": [
-                        {
-                            "id": "wsp",
-                            "title": "White Sand (prose)",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/White_Sand_(prose)'>White Sand (prose)</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Taldain_system'>Taldain system</a>",
-                            "au": "Excerpt included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded.</a>.",
-                            "link": "<a target='_blank' href='https://brandonsanderson.com/newsletter-signup/'>Link to full text found in Brandon's newsletter.</a>",
-                            "publication": "June 2009 (upon request)",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/182/#e3878'>White Sand occurs prior to Elantris.</a>",
-                            "sorting": {
-                                "order": 2.14,
-                                "publication": 2009.06,
-                                "chronology": 2.0
-                            },
-                            "appearances": [
-                                {
-                                    "id": "khriss",
-                                    "type": "appearance",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> is a main character."
-                                }
-                            ],
-                            "categories": [ "white-sand", "novel", "apocryphal", "noncanon" ],
-                            "connections": [
-                                {
-                                    "target": "ws1",
-                                    "type": "minor",
-                                    "description": "The <a target='_blank' href='https://coppermind.net/wiki/White_Sand'>White Sand</a> graphic novels are based on the prose version."
-                                }
-                            ]
-                        },
-                        {
-                            "id": "aon",
-                            "title": "Aether of Night",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Aether_of_Night'>Aether of Night</a>",
-                            "world": "Unknown",
-                            "system": "Unknown",
-                            "link": "<a target='_blank' href='https://www.17thshard.com/forum/topic/60219-aether-of-night-manuscript-requests/'>Full text available from the 17th Shard.</a>",
-                            "publication": "June 2009 (upon request)",
-                            "sorting": {
-				                "order": 2.92,
-                                "publication": 2009.06
-                            },
-                            "categories": [ "no-series", "apocryphal", "noncanon", "novel" ],
-                            "connections": [
-                                {
-                                    "target": "sa2",
-                                    "type": "egg",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Mraize'>Mraize</a>'s collection in <a target='_blank' href='https://coppermind.net/wiki/Summary:Words_of_Radiance#Chapter_43:_The_Ghostbloods'>Chapter 43</a> includes pink <a target='_blank' href='https://coppermind.net/wiki/Aether'>aether</a>."
-                                },
-                                {
-                                    "target": "sa3",
-                                    "type": "egg",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Mraize'>Mraize</a> mentions his suit was stained with <a target='_blank' href='https://coppermind.net/wiki/Aether'>aether</a>."
-                                },
-                                {
-                                    "target": "sa4",
-                                    "type": "egg",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Foil'>Foil</a> is said to be seeking 'control over the <a target='_blank' href='https://coppermind.net/wiki/Aether'>aethers</a>'."
-                                },
+					"id": "elantris",
+					"description": "Elantris",
+					"details": "Elantris and its sequels.",
+					"color": "#58b06e"
+				},
 				{
-				    "target": "mb7",
-				    "type": "minor",
-				    "description": "WIP"
-				}
-                            ]
-                        },
-                        {
-                            "id": "imperial-fool",
-                            "title": "Imperial Fool",
-                            "title2": "Imperial Fool",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Sel'>Sel</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Selish_system'>Selish system</a>",
-                            "link": "<a target='_blank' href='https://brandonsanderson.com/the-emperors-soul-deleted-prologue-imperial-fool'>Full text on Brandon's website.</a>",
-                            "publication": "November 2012",
-                            "chronology": "Concerns events shortly before the events of The Emperor's Soul.",
-                            "sorting": {
-				                "order": 1.41,
-                                "publication": 2012.11,
-                                "chronology": 3.4
-                            },
-                            "appearances": [
-                                {
-                                    "id": "hoid",
-                                    "type": "appearance",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is the 'Imperial Fool'."
-                                }
-                            ],
-                            "categories": [ "no-series", "short", "apocryphal", "noncanon" ],
-			    "connections":[
+					"id": "mistborn",
+					"description": "Mistborn",
+					"details": "Mistborn (all eras)",
+					"color": "#9973bf"
+				},
 				{
-				    "target": "mb7",
-				    "type": "egg",
-				    "description": "WIP"
+					"id": "warbreaker",
+					"description": "Warbreaker",
+					"details": "Warbreaker and its sequel.",
+					"color": "#de4343"
+				},
+				{
+					"id": "stormlight",
+					"description": "Stormlight Archive",
+					"details": "The Stormlight Archive",
+					"color": "#2aa1d4"
+				},
+				{
+					"id": "white-sand",
+					"description": "White Sand",
+					"details": "White Sand and its sequels.",
+					"color": "#d4c955"
+				},
+				{
+					"id": "dragonsteel",
+					"description": "Dragonsteel",
+					"details": "Dragonsteel",
+					"color": "#d98a41"
+				},
+				{
+					"id": "aether",
+					"description": "Aether",
+					"details": "Aether series",
+					"color": "#e3a1e3"
+				},
+				{
+					"id": "no-series",
+					"description": "Non-series Stories",
+					"details": "Stories not part of a series.",
+					"color": "#A0A0A0"
 				}
-			    ]
-                        },
-                        {
-                            "id": "twokp",
-                            "title": "The Way of Kings Prime",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Way_of_Kings_Prime'>The Way of Kings Prime</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-                            "link": "<a target='_blank' href='https://www.brandonsanderson.com/the-way-of-kings-prime/'>Full novel on Brandon's website.</a>",
-                            "publication": "July 2020",
-                            "sorting": {
-				                "order": 2.91,
-                                "publication": 2020.07
-                            },
-                            "categories": [ "stormlight", "novel", "apocryphal", "noncanon" ]
-                        },
-                        {
-                            "id": "jasnah",
-                            "title": "Jasnah deleted scene",
-                            "title2": "Jasnah deleted scene",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-                            "link": "<a target='_blank' href='https://www.tor.com/2014/08/06/stormlight-archive-scene-after-words-of-radiance'>Full text on Tor.com.</a>",
-                            "publication": "August 2014",
-                            "chronology": "Occurs during the early events of Words of Radiance.",
-                            "sorting": {
-				                "order": 2.421,
-                                "publication": 2014.08,
-                                "chronology": 7.021
-                            },
-                            "categories": [ "stormlight", "short", "apocryphal", "noncanon" ]
-                        },
-                        {
-                            "id": "traveler",
-                            "title": "The Traveler",
-                            "title2": "The Traveler",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Yolen'>Yolen</a>",
-                            "system": "Yolish system",
-                            "link": "<a target='_blank' href='https://wob.coppermind.net/events/332/#e9518'>Full text on Arcanum.</a>",
-                            "publication": "April 2018",
-                            "chronology": "Occurs shortly after Mistborn Era 1.",
-                            "sorting": {
-                                "order": 2.26,
-                                "publication": 2018.04,
-                                "chronology": 4.5
-                            },
-                            "appearances": [
-                                {
-                                    "id": "hoid",
-                                    "type": "appearance",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is 'the Traveler'."
-                                }
-                            ],
-                            "categories": [ "no-series", "short", "apocryphal", "noncanon" ]
-                        }
-                    ]
-                }
-            ]
-        }
-    ]
+			]
+		},
+		{
+			"id": "reading-order",
+			"name": "Reading Order",
+			"categories": [
+				{
+					"id": "phase1",
+					"description": "Phase 1 - Essential",
+					"details": "Essential Phase 1 stories should be read before moving to Phase 2.",
+					"color": "#00b02b"
+				},
+				{
+					"id": "phase1b",
+					"description": "Phase 1 - Secondary",
+					"details": "Secondary Phase 1 stories may be read during Phase 1 or anytime after.",
+					"color": "#7bb088"
+				},
+				{
+					"id": "phase2",
+					"description": "Phase 2 - Essential",
+					"details": "Essential Phase 2 stories should be read after all essential Phase 1 works and before moving to Phase 3.",
+					"color": "#0094d4"
+				},
+				{
+					"id": "phase2b",
+					"description": "Phase 2 - Secondary",
+					"details": "Secondary Phase 2 stories may be read during Phase 2 or anytime after.",
+					"color": "#8abdd4"
+				},
+				{
+					"id": "plan",
+					"description": "Unpublished - Future Plans",
+					"details": "Includes all planned future cosmere stories. Likelihood of publication varies. Known publication dates may be in parenthesis. Titles are tentative.",
+					"color": "#505050"
+				},
+				{
+					"id": "apocryphal",
+					"description": "Unpublished - Apocryphal",
+					"details": "Includes unpublished, apocryphal stories. Some elements may be part of the official continuity. Some may be published in the future while others will not.",
+					"color": "#735a45"
+				}
+			]
+		},
+		{
+			"id": "formats",
+			"name": "Formats",
+			"startCollapsed": true,
+			"categories": [
+				{
+					"id": "novel",
+					"description": "Novels",
+					"details": "Full novels.",
+					"color": "#fc4422"
+				},
+				{
+					"id": "graphic",
+					"description": "Graphic Novels",
+					"details": "Graphic novels.",
+					"style": "italic",
+					"color": "#fe8062"
+				},
+				{
+					"id": "novella",
+					"description": "Novellas",
+					"details": "Novellas.",
+					"style": "italic",
+					"color": "#ffc8ba"
+				},
+				{
+					"id": "short",
+					"description": "Short Stories",
+					"details": "Short stories.",
+					"style": "italic",
+					"color": "#fbe8e6"
+				}
+			]
+		}
+	],
+	"sorting": [
+		{
+			"id": "order",
+			"description": "Reading order"
+		},
+		{
+			"id": "publication",
+			"description": "Publication date"
+		},
+		{
+			"id": "chronology",
+			"description": "Cosmere timeline"
+		}
+	],
+	"appearances": [
+		{
+			"id": "hoid",
+			"description": "Hoid",
+			"initial": "H",
+			"color": "#A0A0A0",
+			"details": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a>'s appearances (solid) and mentions (outline)."
+		},
+		{
+			"id": "khriss",
+			"description": "Khriss",
+			"initial": "K",
+			"color": "#A0A0A0",
+			"details": "<a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a>'s appearances (solid) and mentions (outline), not counting the <a target='_blank' href='https://coppermind.net/wiki/Ars_Arcanum'>Ars Arcanum</a>."
+		},
+		{
+			"id": "nazh",
+			"description": "Nazh",
+			"initial": "N",
+			"color": "#A0A0A0",
+			"details": "<a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a>'s appearances (solid) and mentions (outline)."
+		},
+		{
+			"id": "ars",
+			"description": "Ars Arcanum",
+			"initial": "A",
+			"color": "#A0A0A0",
+			"details": "Stories that include an <a target='_blank' href='https://coppermind.net/wiki/Ars_Arcanum'>Ars Arcanum</a>."
+		}
+	],
+	"books": [
+		{
+			"label": "Sel",
+			"color": "#58b06e",
+			"children": [
+				{
+					"label": "Elantris",
+					"children": [
+						{
+							"id": "elantris",
+							"title": "Elantris",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Elantris'>Elantris</a>",
+							"series": "Elantris",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Sel'>Sel</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Selish_system'>Selish system</a>",
+							"publication": "April 2005",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/298/#e9926'>Occurs long before Mistborn Era 1, but not thousands of years before.</a>",
+							"sorting": {
+								"order": 1.3,
+								"publication": 2005.04,
+								"chronology": 3.1
+							},
+							"appearances": [
+								{
+									"id": "hoid",
+									"type": "appearance",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a>'s first appearance. <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is the beggar that works with <a target='_blank' href='https://coppermind.net/wiki/Sarene'>Sarene</a> in <a target='_blank' href='https://coppermind.net/wiki/Summary:Elantris#Chapter_58'>Chapter 58</a>. The tenth anniversary edition includes <a target='_blank' href='https://coppermind.net/wiki/Summary:Elantris#Postscript'>a postscript</a> with <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> in it."
+								},
+								{
+									"id": "nazh",
+									"type": "mention",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a>'s annotations can be found on the map of <a target='_blank' href='https://coppermind.net/wiki/Sycla'>Sycla</a>."
+								},
+								{
+									"id": "ars",
+									"type": "appearance"
+								}
+							],
+							"categories": [
+								"elantris",
+								"phase1",
+								"published",
+								"novel"
+							],
+							"connections": [
+								{
+									"target": "tes",
+									"type": "minor",
+									"description": "The map in <a target='_blank' href='https://coppermind.net/wiki/Elantris'>Elantris</a> refers to '<a target='_blank' href='https://coppermind.net/wiki/Rose_Empire'>Rose Barbarians</a>'. There are mentions of <a target='_blank' href='https://coppermind.net/wiki/Svorden'>Svorden</a>, <a target='_blank' href='https://coppermind.net/wiki/Teod'>Teod</a>, and <a target='_blank' href='https://coppermind.net/wiki/Sycla'>Sycla</a>. When escaping the palace, <a target='_blank' href='https://coppermind.net/wiki/Shai'>Shai</a> runs into a <a target='_blank' href='https://coppermind.net/wiki/Shu-Dereth'>Derethi priest</a> (wearing red armor). When she steals the painting she inscribes an <a target='_blank' href='https://coppermind.net/wiki/Aon'>Aon Reo</a> in its place."
+								},
+								{
+									"target": "msh",
+									"type": "significant",
+									"description": "The <a target='_blank' href='https://coppermind.net/wiki/Ire'>Ire</a> are <a target='_blank' href='https://coppermind.net/wiki/Elantrian'>Elantrians</a>. Their symbol is <a target='_blank' href='https://coppermind.net/wiki/Aon'>Aon Ire</a>."
+								},
+								{
+									"target": "sa1",
+									"type": "egg",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Galladon'>Galladon</a> appears in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Way_of_Kings#Interlude_I-1:_Ishikk'>Interlude I-1</a> as 'Grump'. Note his use of 'sule' (friend) and 'kolo' (understand) as well as the <a target='_blank' href='https://coppermind.net/wiki/Duladel'>Dula</a> word 'kayana' (crazy). Also, <a target='_blank' href='https://coppermind.net/wiki/Aona'>Aona</a> and <a target='_blank' href='https://coppermind.net/wiki/Skai'>Skai</a> are mentioned in the <a target='_blank' href='https://coppermind.net/wiki/https://coppermind.net/wiki/The_Way_of_Kings/Epigraphs#The_Letter'>Chapter 22 epigraph</a>."
+								},
+								{
+									"target": "sa3",
+									"type": "minor",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Riino'>Riino</a>, the lighthouse owner in <a target='_blank' href='https://coppermind.net/wiki/Summary:Oathbringer#Chapter_97:_Riino'>Chapter 97</a>, is the <a target='_blank' href='https://coppermind.net/wiki/Hoed'>Hoed</a> <a target='_blank' href='https://coppermind.net/wiki/Raoden'>Raoden</a> and <a target='_blank' href='https://coppermind.net/wiki/Galladon'>Galladon</a> lowered into the <a target='_blank' href='https://coppermind.net/wiki/Devotion's_Perpendicularity'>mountain lake</a>."
+								},
+								{
+									"target": "au",
+									"type": "minor",
+									"description": "The nature of <a target='_blank' href='https://coppermind.net/wiki/Sel'>Sel</a>'s magic is discussed in the <a target='_blank' href='https://coppermind.net/wiki/Selish_system'>Selish system</a> essay."
+								},
+								{
+									"target": "sa4",
+									"type": "minor",
+									"description": "The communication box used by <a target='_blank' href='https://coppermind.net/wiki/Shallan'>Shallan</a> to communicate with <a target='_blank' href='https://coppermind.net/wiki/Mraize'>Mraize</a> and <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> contains a <a target='_blank' href='https://coppermind.net/wiki/Seon'>Seon</a>."
+								},
+								{
+									"target": "mb7",
+									"type": "major",
+									"description": "(WIP) Codenames is Kaise. Shay-I (Moonlight) uses AonDor in chapter 54. Codenames communicate with Kelsier using Seon Dao"
+								}
+							]
+						},
+						{
+							"id": "thoe",
+							"title": "The Hope of Elantris",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Hope_of_Elantris'>The Hope of Elantris</a>",
+							"series": "Elantris",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Sel'>Sel</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Selish_system'>Selish system</a>",
+							"au": "Included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
+							"link": "<a target='_blank' href='https://brandonsanderson.com/elantris-the-hope-of-elantris'>Full text on Brandon's website.</a>",
+							"padding": 12,
+							"publication": "January 2006",
+							"chronology": "Shortly after the events of Elantris, and concerning events during the end of that book.",
+							"sorting": {
+								"order": 1.31,
+								"publication": 2006.01,
+								"chronology": 3.11
+							},
+							"categories": [
+								"elantris",
+								"phase1b",
+								"published",
+								"short"
+							]
+						},
+						{
+							"id": "elantris2",
+							"title": "Elantris 2",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Elantris_sequel'>Elantris 2</a>",
+							"series": "Elantris",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Sel'>Sel</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Selish_system'>Selish system</a>",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/395/#e13072'>A short time jump is planned between Elantris books, with the original main characters still being alive.</a>",
+							"sorting": {
+								"chronology": 3.2
+							},
+							"categories": [
+								"elantris",
+								"plan",
+								"unpublished",
+								"novel"
+							]
+						},
+						{
+							"id": "elantris3",
+							"title": "Elantris 3",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Elantris_finale'>Elantris 3</a>",
+							"series": "Elantris",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Sel'>Sel</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Selish_system'>Selish system</a>",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/395/#e13072'>A short time jump is planned between Elantris books, with the original main characters still being alive.</a>",
+							"sorting": {
+								"chronology": 3.3
+							},
+							"categories": [
+								"elantris",
+								"plan",
+								"unpublished",
+								"novel"
+							]
+						}
+					]
+				},
+				{
+					"children": [
+						{
+							"id": "tes",
+							"title": "The Emperor's Soul",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Emperor&#39s_Soul'>The Emperor's Soul</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Sel'>Sel</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Selish_system'>Selish system</a>",
+							"au": "Included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
+							"publication": "November 2012",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/109/#e1410'>After Elantris, but within the characters' lifetimes.</a> Note this could place it prior to Elantris 2 and/or 3.",
+							"sorting": {
+								"order": 1.4,
+								"publication": 2012.11,
+								"chronology": 3.5
+							},
+							"appearances": [
+								{
+									"id": "hoid",
+									"type": "mention",
+									"description": "The 'Imperial Fool' is <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a>."
+								}
+							],
+							"categories": [
+								"no-series",
+								"phase1b",
+								"published",
+								"novella"
+							],
+							"connections": [
+								{
+									"target": "imperial-fool",
+									"type": "major",
+									"description": "A deleted prologue that contains some canonical elements."
+								},
+								{
+									"target": "au",
+									"type": "minor",
+									"description": "The nature of <a target='_blank' href='https://coppermind.net/wiki/Sel'>Sel</a>'s magic is discussed in the <a target='_blank' href='https://coppermind.net/wiki/Selish_system'>Selish system</a> essay."
+								},
+								{
+									"target": "sa4",
+									"type": "egg",
+									"description": "The <a target='_blank' href='https://coppermind.net/wiki/Fused'>Fused</a> refer to <a target='_blank' href='https://coppermind.net/wiki/aluminum'>aluminum</a> as Ralkalest."
+								},
+								{
+									"target": "mb7",
+									"type": "major",
+									"description": "(WIP) Moonlight is Shai; she uses Forgery on several occasions and takes on the name Shay-I after using her essence marks"
+								}
+							]
+						},
+						{
+							"id": "tes2",
+							"title": "The Emperor's Soul sequel",
+							"title2": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>Untitled Emperor's Soul sequel</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Sel'>Sel</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Selish_system'>Selish system</a>",
+							"categories": [
+								"no-series",
+								"plan",
+								"unpublished",
+								"novella"
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"label": "Scadrial",
+			"color": "#9973bf",
+			"children": [
+				{
+					"label": "Mistborn<br>Era 1",
+					"children": [
+						{
+							"id": "mb1",
+							"title": "Mistborn: The Final Empire",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn:_The_Final_Empire'>Mistborn: The Final Empire</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 1)",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
+							"publication": "July 2006",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/176/#e8494'>Mistborn Era 1 occurs prior to The Stormlight Archive.",
+							"sorting": {
+								"order": 1.11,
+								"publication": 2006.07,
+								"chronology": 4.1
+							},
+							"appearances": [
+								{
+									"id": "hoid",
+									"type": "appearance",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Kelsier'>Kelsier</a> meets with <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> in <a target='_blank' href='https://coppermind.net/wiki/Summary:Mistborn:_The_Final_Empire#Chapter_19'>Chapter 19</a>."
+								},
+								{
+									"id": "nazh",
+									"type": "mention",
+									"description": "Annotations by <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> can be found on the map of <a target='_blank' href='https://coppermind.net/wiki/Luthadel'>Luthadel</a>."
+								},
+								{
+									"id": "ars",
+									"type": "appearance"
+								}
+							],
+							"categories": [
+								"mistborn",
+								"phase1",
+								"published",
+								"novel"
+							]
+						},
+						{
+							"id": "11m",
+							"title": "The Eleventh Metal",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Eleventh_Metal'>The Eleventh Metal</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 1)",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
+							"au": "Included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
+							"padding": 12,
+							"publication": "December 2011",
+							"chronology": "Concerns Kelsier's training, years before Mistborn: The Final Empire.",
+							"sorting": {
+								"order": 1.14,
+								"publication": 2011.12,
+								"chronology": 4.09
+							},
+							"categories": [
+								"mistborn",
+								"short",
+								"phase1b",
+								"published"
+							]
+						},
+						{
+							"id": "mb2",
+							"title": "The Well of Ascension",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Well_of_Ascension'>The Well of Ascension</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 1)",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
+							"publication": "August 2007",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/176/#e8494'>Mistborn Era 1 occurs prior to The Stormlight Archive.",
+							"sorting": {
+								"order": 1.12,
+								"publication": 2007.08,
+								"chronology": 4.2
+							},
+							"appearances": [
+								{
+									"id": "hoid",
+									"type": "appearance",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is among the <a target='_blank' href='https://coppermind.net/wiki/Terris'>Terris</a> refugees in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Well_of_Ascension#Chapter_56'>Chapter 56</a>, <a target='_blank' href='https://wob.coppermind.net/events/130/#e1552'>according to Brandon</a>."
+								},
+								{
+									"id": "nazh",
+									"type": "mention",
+									"description": "Annotations by <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> can be found on the map of <a target='_blank' href='https://coppermind.net/wiki/Luthadel'>Luthadel</a>."
+								},
+								{
+									"id": "ars",
+									"type": "appearance"
+								}
+							],
+							"categories": [
+								"mistborn",
+								"phase1",
+								"published",
+								"novel"
+							],
+							"connections": [
+								{
+									"target": "wb",
+									"type": "egg",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Lemex%27s_nurse'>Lemex's nurse</a> is a <a target='_blank' href='https://coppermind.net/wiki/Terris'>Terriswoman</a>."
+								}
+							]
+						},
+						{
+							"id": "mb3",
+							"title": "The Hero of Ages",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Hero_of_Ages'>The Hero of Ages</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 1)",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
+							"publication": "October 2008",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/176/#e8494'>Mistborn Era 1 occurs prior to The Stormlight Archive.",
+							"sorting": {
+								"order": 1.13,
+								"publication": 2008.1,
+								"chronology": 4.3
+							},
+							"appearances": [
+								{
+									"id": "hoid",
+									"type": "mention",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is the informant that <a target='_blank' href='https://coppermind.net/wiki/Vin'>Vin</a> was supposed to meet with in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Hero_of_Ages#Chapter_27'>Chapter 27</a>."
+								},
+								{
+									"id": "nazh",
+									"type": "mention",
+									"description": "Annotations by <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> can be found on the map of <a target='_blank' href='https://coppermind.net/wiki/Luthadel'>Luthadel</a>."
+								},
+								{
+									"id": "ars",
+									"type": "appearance"
+								}
+							],
+							"categories": [
+								"mistborn",
+								"phase1",
+								"published",
+								"novel"
+							],
+							"connections": [
+								{
+									"target": "sa1",
+									"type": "egg",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Demoux'>Demoux</a> appears in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Way_of_Kings#Interlude_I-1:_Ishikk'>Interlude I-1</a> as 'Thinker'; <a target='_blank' href='https://coppermind.net/wiki/Ishikk'>Ishikk</a> mishears his name as 'Temoo'. <a target='_blank' href='https://coppermind.net/wiki/Ruin'>Ruin</a>'s <a target='_blank' href='https://coppermind.net/wiki/vessel'>vessel</a>, <a target='_blank' href='https://coppermind.net/wiki/Ati'>Ati</a>, is mentioned in the <a target='_blank' href='https://coppermind.net/wiki/https://coppermind.net/wiki/The_Way_of_Kings/Epigraphs#The_Letter'>Chapter 18 epigraph</a>. <a target='_blank' href='https://coppermind.net/wiki/Felt'>Felt</a> worked for the <a target='_blank' href='https://coppermind.net/wiki/House_Venture'>House Venture</a> on <a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>."
+								},
+								{
+									"target": "sa2",
+									"type": "egg",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Wit</a> appears to use <a target='_blank' href='https://coppermind.net/wiki/Allomancy'>emotional Allomancy</a> in <a target='_blank' href='https://coppermind.net/wiki/Summary:Words_of_Radiance#Chapter_45:_Middlefest'>Chapter 45</a>."
+								},
+								{
+									"target": "sa3",
+									"type": "significant",
+									"description": "The <a target='_blank' href='https://coppermind.net/wiki/Oathbringer/Epigraphs#Letters'>Part 2 epigraphs</a> include <a target='_blank' href='https://coppermind.net/wiki/Letters#Third_Oathbringer_Letter'>a letter</a> from <a target='_blank' href='https://coppermind.net/wiki/Sazed'>Sazed</a> to <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a>. <a target='_blank' href='https://coppermind.net/wiki/Felt'>Felt</a> reveals he is from another world."
+								},
+								{
+									"target": "au",
+									"type": "major",
+									"description": "The <a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a> essay discusses the events that occurred in <a target='_blank' href='https://coppermind.net/wiki/The_Hero_of_Ages'>The Hero of Ages</a>."
+								},
+								{
+									"target": "sa4",
+									"type": "significant",
+									"description": "The <a target='_blank' href='https://coppermind.net/wiki/Rhythm_of_War/Epigraphs'>Part 2 Epigraphs</a> are a letter from <a target='_blank' href='https://coppermind.net/wiki/Harmony'>Harmony</a>. <a target='_blank' href='https://coppermind.net/wiki/Fabrial'>Fabrial</a> metals have similar effects as in the <a target='_blank' href='https://coppermind.net/wiki/Metallic_Arts'>Metalic Arts</a>. <a target='_blank' href='https://coppermind.net/wiki/Gereh'>Gereh</a> and <a target='_blank' href='https://coppermind.net/wiki/Axindweth'>Axindweth</a> are <a target='_blank' href='https://coppermind.net/wiki/Feruchemy'>Feruchemists</a>. <a target='_blank' href='https://coppermind.net/wiki/Raysium'>Raysium</a> is associated with <a target='_blank' href='https://coppermind.net/wiki/Odium'>Odium</a> as <a target='_blank' href='https://coppermind.net/wiki/atium'>atium</a> is associated with <a target='_blank' href='https://coppermind.net/wiki/Ruin'>Ruin</a>."
+								}
+							]
+						}
+					]
+				},
+				{
+					"label": "Mistborn<br>Era 2",
+					"children": [
+						{
+							"id": "mb4",
+							"title": "The Alloy of Law",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Alloy_of_Law'>The Alloy of Law</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 2)",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
+							"publication": "November 2011",
+							"chronology": "Mistborn Era 2 occurs <a target='_blank' href='https://wob.coppermind.net/events/260/#e8747'>after Stormlight Archive book 5</a> and <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>before Stormlight Archive book 6</a>.",
+							"sorting": {
+								"order": 2.21,
+								"publication": 2011.11,
+								"chronology": 8.1
+							},
+							"appearances": [
+								{
+									"id": "hoid",
+									"type": "appearance",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is the beggar speaking with <a target='_blank' href='https://coppermind.net/wiki/Joshin_Yomen'>Lord Joshin</a> and <a target='_blank' href='https://coppermind.net/wiki/Mi%27chelle_Yomen'>Lady Mi'chelle</a> in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Alloy_of_Law#Chapter_4'>Chapter 4</a>."
+								},
+								{
+									"id": "nazh",
+									"type": "mention",
+									"description": "Annotations by <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> can be found on the map of <a target='_blank' href='https://coppermind.net/wiki/Elendel'>Elendel</a>."
+								},
+								{
+									"id": "ars",
+									"type": "appearance"
+								}
+							],
+							"categories": [
+								"mistborn",
+								"phase2",
+								"published",
+								"novel"
+							]
+						},
+						{
+							"id": "jak",
+							"title": "Allomancer Jak",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Allomancer_Jak_and_the_Pits_of_Eltania'>Allomancer Jak and the Pits of Eltania</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 2)",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
+							"au": "Included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
+							"padding": 12,
+							"publication": "August 2014",
+							"chronology": "Mistborn Era 2 occurs <a target='_blank' href='https://wob.coppermind.net/events/260/#e8747'>after Stormlight Archive book 5</a> and <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>before Stormlight Archive book 6</a>.",
+							"sorting": {
+								"order": 2.22,
+								"publication": 2014.08,
+								"chronology": 8.05
+							},
+							"categories": [
+								"mistborn",
+								"short",
+								"phase2b",
+								"published"
+							]
+						},
+						{
+							"id": "mb5",
+							"title": "Shadows of Self",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Shadows_of_Self'>Shadows of Self</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 2)",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
+							"publication": "October 2015",
+							"chronology": "Mistborn Era 2 occurs <a target='_blank' href='https://wob.coppermind.net/events/260/#e8747'>after Stormlight Archive book 5</a> and <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>before Stormlight Archive book 6</a>.",
+							"sorting": {
+								"order": 2.23,
+								"publication": 2015.1,
+								"chronology": 8.2
+							},
+							"appearances": [
+								{
+									"id": "hoid",
+									"type": "appearance",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is <a target='_blank' href='https://coppermind.net/wiki/Waxillium_Laddrian'>Wax</a>'s coachman, named in <a target='_blank' href='https://coppermind.net/wiki/Summary:Shadows_of_Self#Chapter_7'>Chapter 7</a>."
+								},
+								{
+									"id": "ars",
+									"type": "appearance"
+								}
+							],
+							"categories": [
+								"mistborn",
+								"phase2",
+								"published",
+								"novel"
+							]
+						},
+						{
+							"id": "mb6",
+							"title": "The Bands of Mourning",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Bands_of_Mourning'>The Bands of Mourning</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 2)",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
+							"publication": "January 2016",
+							"chronology": "Mistborn Era 2 occurs <a target='_blank' href='https://wob.coppermind.net/events/260/#e8747'>after Stormlight Archive book 5</a> and <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>before Stormlight Archive book 6</a>.",
+							"sorting": {
+								"order": 2.24,
+								"publication": 2016.01,
+								"chronology": 8.3
+							},
+							"appearances": [
+								{
+									"id": "hoid",
+									"type": "appearance",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is the beggar who gives <a target='_blank' href='https://coppermind.net/wiki/Waxillium_Laddrian'>Wax</a> a special coin in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Bands_of_Mourning#Chapter_11'>Chapter 11</a>."
+								},
+								{
+									"id": "khriss",
+									"type": "appearance",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> is the woman who dances with <a target='_blank' href='https://coppermind.net/wiki/Waxillium_Laddrian'>Wax</a> in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Bands_of_Mourning#Chapter_12'>Chapter 12</a>. <a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> and <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> are also the 'K or N' referred to in the 'Do your metal tools speak to you?' ad in <a target='_blank' href='https://coppermind.net/wiki/The_New_Ascendancy'>The New Ascendancy</a> broadsheet."
+								},
+								{
+									"id": "nazh",
+									"type": "mention",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> is 'the haunted man' in 'The Ghastly Gondola!' story in <a target='_blank' href='https://coppermind.net/wiki/The_New_Ascendancy'>The New Ascendancy</a> broadsheet. (note his 'shadows' curse) <a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> and <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> are also the 'K or N' referred to in the 'Do your metal tools speak to you?' ad in the broadsheet."
+								},
+								{
+									"id": "ars",
+									"type": "appearance"
+								}
+							],
+							"categories": [
+								"mistborn",
+								"phase2",
+								"published",
+								"novel"
+							],
+							"connections": [
+								{
+									"target": "sa2",
+									"type": "egg",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Iyatil'>Iyatil</a> is of <a target='_blank' href='https://coppermind.net/wiki/Southern_Scadrial'>Southern Scadrian</a> descent."
+								},
+								{
+									"target": "msh",
+									"type": "major",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Kelsier'>Kelsier</a>'s survival is revealed in <a target='_blank' href='https://coppermind.net/wiki/The_Bands_of_Mourning'>The Bands of Mourning</a>."
+								},
+								{
+									"target": "sotd2",
+									"type": "minor",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrian</a> spaceships powered by <a target='_blank' href='https://coppermind.net/wiki/Allomancy'>Allomancy</a> are seen."
+								}
+							]
+						},
+						{
+							"id": "mb7",
+							"title": "The Lost Metal (2022)",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Lost_Metal'>The Lost Metal</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 2)",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
+							"publication": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>Fall 2022</a>",
+							"chronology": "Mistborn Era 2 occurs <a target='_blank' href='https://wob.coppermind.net/events/260/#e8747'>after Stormlight Archive book 5</a> and <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>before Stormlight Archive book 6</a>.",
+							"sorting": {
+								"publication": 2022.11,
+								"chronology": 8.4
+							},
+							"appearances": [
+								{
+									"id": "hoid",
+									"type": "appearance",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is <a target='_blank' href='https://coppermind.net/wiki/Waxillium_Laddrian'>Wax</a>'s coachman, named for the first time in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Lost_Metal#Chapter_7'>Chapter 7</a>."
+								},
+								{
+									"id": "nazh",
+									"type": "mention",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> is 'the haunted man' in 'Nicki Savage and The Compass of Spirits' story in <a target='_blank' href='https://coppermind.net/wiki/The_Two_Seasons'>The Two Seasons</a> broadsheet."
+								},
+								{
+									"id": "ars",
+									"type": "appearance"
+								}
+							],
+							"categories": [
+								"mistborn",
+								"plan",
+								"forthcoming",
+								"novel"
+							]
+						},
+						{
+							"id": "nicki",
+							"title": "Boatload of Mummies",
+							"title2": "<a target='_blank' href='https://wob.coppermind.net/events/479/#e15159'>Boatload of Mummies</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 2)",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
+							"chronology": "Mistborn Era 2 occurs <a target='_blank' href='https://wob.coppermind.net/events/260/#e8747'>after Stormlight Archive book 5</a> and <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>before Stormlight Archive book 6</a>.",
+							"padding": 12,
+							"sorting": {
+								"chronology": 8.5
+							},
+							"categories": [
+								"mistborn",
+								"short",
+								"plan",
+								"unpublished"
+							]
+						}
+					]
+				},
+				{
+					"label": "Mistborn<br>Era 3",
+					"children": [
+						{
+							"id": "mb8",
+							"title": "Mistborn Era 3 Book 1",
+							"title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=mistborn+era+3'>Mistborn Era 3 Book 1</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 3)",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>Fifty to seventy years after Mistborn Era 2. After Stormlight Archive book 10.</a> Prior to Mistborn Era 4.",
+							"publication": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>2024 (best guess)</a>",
+							"sorting": {
+								"chronology": 10.1,
+								"publication": 2024
+							},
+							"categories": [
+								"mistborn",
+								"plan",
+								"unpublished",
+								"novel"
+							]
+						},
+						{
+							"id": "mb9",
+							"title": "Mistborn Era 3 Book 2",
+							"title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=mistborn+era+3'>Mistborn Era 3 Book 2</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 3)",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>Fifty to seventy years after Mistborn Era 2. After Stormlight Archive book 10.</a> Prior to Mistborn Era 4.",
+							"publication": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>2025 (best guess)</a>",
+							"sorting": {
+								"chronology": 10.2,
+								"publication": 2025
+							},
+							"categories": [
+								"mistborn",
+								"plan",
+								"unpublished",
+								"novel"
+							]
+						},
+						{
+							"id": "mb10",
+							"title": "Mistborn Era 3 Book 3",
+							"title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=mistborn+era+3'>Mistborn Era 3 Book 3</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 3)",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>Fifty to seventy years after Mistborn Era 2. After Stormlight Archive book 10.</a> Prior to Mistborn Era 4.",
+							"publication": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>2026 (best guess)</a>",
+							"sorting": {
+								"chronology": 10.3,
+								"publication": 2026
+							},
+							"categories": [
+								"mistborn",
+								"plan",
+								"unpublished",
+								"novel"
+							]
+						}
+					]
+				},
+				{
+					"label": "Mistborn<br>Era 4",
+					"children": [
+						{
+							"id": "mb11",
+							"title": "Mistborn Era 4 Book 1",
+							"title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=mistborn+era+4'>Mistborn Era 4 Book 1</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 4)",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/182/#e3884'>Mistborn Era 4 is the finale of the cosmere storyline.</a>",
+							"sorting": {
+								"chronology": 13.1
+							},
+							"categories": [
+								"mistborn",
+								"plan",
+								"unpublished",
+								"novel"
+							]
+						},
+						{
+							"id": "mb12",
+							"title": "Mistborn Era 4 Book 2",
+							"title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=mistborn+era+4'>Mistborn Era 4 Book 2</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 4)",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/182/#e3884'>Mistborn Era 4 is the finale of the cosmere storyline.</a>",
+							"sorting": {
+								"chronology": 13.2
+							},
+							"categories": [
+								"mistborn",
+								"plan",
+								"unpublished",
+								"novel"
+							]
+						},
+						{
+							"id": "mb13",
+							"title": "Mistborn Era 4 Book 3",
+							"title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=mistborn+era+4'>Mistborn Era 4 Book 3</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 4)",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/182/#e3884'>Mistborn Era 4 is the finale of the cosmere storyline.</a>",
+							"sorting": {
+								"chronology": 13.3
+							},
+							"categories": [
+								"mistborn",
+								"plan",
+								"unpublished",
+								"novel"
+							]
+						}
+					]
+				},
+				{
+					"label": "Other<br>Mistborn",
+					"children": [
+						{
+							"id": "msh",
+							"title": "Mistborn: Secret History",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn:_Secret_History'>Mistborn: Secret History</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
+							"au": "Included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
+							"publication": "January 2016",
+							"chronology": "Happens concurrently with Mistborn Era 1.",
+							"sorting": {
+								"order": 2.25,
+								"publication": 2016.01,
+								"chronology": 4.11
+							},
+							"appearances": [
+								{
+									"id": "hoid",
+									"type": "appearance",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is 'Drifter'."
+								},
+								{
+									"id": "khriss",
+									"type": "appearance",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Kelsier'>Kelsier</a> meets <a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> and <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> in the <a target='_blank' href='https://coppermind.net/wiki/Cognitive_Realm'>Cognitive Realm</a>."
+								},
+								{
+									"id": "nazh",
+									"type": "appearance",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Kelsier'>Kelsier</a> meets <a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> and <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> in the <a target='_blank' href='https://coppermind.net/wiki/Cognitive_Realm'>Cognitive Realm</a>."
+								}
+							],
+							"categories": [
+								"mistborn",
+								"novella",
+								"phase2",
+								"published"
+							],
+							"connections": [
+								{
+									"target": "sa1",
+									"type": "egg",
+									"description": "In <a target='_blank' href='https://coppermind.net/wiki/Summary:Mistborn:_Secret_History#Chapter_2_5'>Part 5 Chapter 2</a> <a target='_blank' href='https://coppermind.net/wiki/Kelsier'>Kelsier</a> sees an <a target='_blank' href='https://coppermind.net/wiki/Fabrial'>alerter fabrial</a> (the glowing yellow gemstone in a golden metal lattice)."
+								},
+								{
+									"target": "sa2",
+									"type": "egg",
+									"description": "With powers gained from the <a target='_blank' href='https://coppermind.net/wiki/lerasium'>lerasium</a> he took, <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> uses <a target='_blank' href='https://coppermind.net/wiki/Allomancy'>emotional Allomancy</a> in <a target='_blank' href='https://coppermind.net/wiki/Summary:Words_of_Radiance#Chapter_45:_Middlefest'>Chapter 45</a>."
+								},
+								{
+									"target": "traveler",
+									"type": "major",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> and <a target='_blank' href='https://coppermind.net/wiki/Frost'>Frost</a> discuss the events of <a target='_blank' href='https://coppermind.net/wiki/The_Hero_of_Ages'>The Hero of Ages</a> (and <a target='_blank' href='https://coppermind.net/wiki/Mistborn:_Secret_History'>Mistborn: Secret History</a>)."
+								},
+								{
+									"target": "sa4",
+									"type": "significant",
+									"description": "Thaidakar, leader of the <a target='_blank' href='https://coppermind.net/wiki/Ghostbloods'>Ghostbloods</a> is <a target='_blank' href='https://coppermind.net/wiki/Kelsier'>Kelsier</a>, with the fight between him and <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> in <a target='_blank' href='https://coppermind.net/wiki/Mistborn:_Secret_History'>Secret History</a> specifically referenced. <a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a> is referenced in <a target='_blank' href='https://coppermind.net/wiki/Ialai'>Ialai's</a> notes. The device used by the <a target='_blank' href='https://coppermind.net/wiki/honorspren'>honorspren</a> to store <a target='_blank' href='https://coppermind.net/wiki/Stormlight'>Stormlight</a> came from the <a target='_blank' href='https://coppermind.net/wiki/Ire'>Ire</a>."
+								},
+								{
+									"target": "mb7",
+									"type": "significant",
+									"description": "(WIP) Kelsier's survival is made explicit in Secret History. The glowing jars that the Ire are using are likely purified Dor."
+								}
+							]
+						},
+						{
+							"id": "msh2",
+							"title": "Mistborn: Secret History 2",
+							"title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=mistborn%3A+secret+history+2'>Mistborn: Secret History 2</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
+							"categories": [
+								"mistborn",
+								"novella",
+								"plan",
+								"unpublished"
+							]
+						},
+						{
+							"id": "mb-cyberpunk",
+							"title": "Cyberpunk Mistborn",
+							"title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?query=cyberpunk%2Bmistborn&date_from=2003-12-05&date_to=2019-11-20&speaker=&ordering=rank'>Cyberpunk Mistborn</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
+							"chronology": "A cyberpunk Mistborn series would be in a <a target='_blank' href='https://wob.coppermind.net/events/34/#e1782'>near-future setting</a>, between Eras 3 and 4.",
+							"sorting": {
+								"chronology": 10.7
+							},
+							"categories": [
+								"mistborn",
+								"plan",
+								"unpublished",
+								"novel"
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"label": "Nalthis",
+			"color": "#de4343",
+			"children": [
+				{
+					"label": "Warbreaker",
+					"color": "#de4343",
+					"children": [
+						{
+							"id": "wb",
+							"title": "Warbreaker",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Warbreaker'>Warbreaker</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Nalthis'>Nalthis</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Nalthian_system'>Nalthian system</a>",
+							"publication": "June 2009",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/309/#e10273'>Occurs after Mistborn Era 1 and before The Stormlight Archive.</a>",
+							"link": "Full text: <a target='_blank' href='https://www.brandonsanderson.com/warbreaker-rights-and-downloads/'>Brandon's website</a> | <a target='_blank' href='https://github.com/guusj/books'>Alternate file types</a>",
+							"sorting": {
+								"order": 1.2,
+								"publication": 2009.06,
+								"chronology": 5.1
+							},
+							"appearances": [
+								{
+									"id": "hoid",
+									"type": "appearance",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is the master storyteller in <a target='_blank' href='https://coppermind.net/wiki/Summary:Warbreaker#Chapter_32'>Chapter 32</a>."
+								},
+								{
+									"id": "ars",
+									"type": "appearance"
+								}
+							],
+							"categories": [
+								"warbreaker",
+								"phase1",
+								"published",
+								"novel"
+							],
+							"connections": [
+								{
+									"target": "sa2",
+									"type": "significant",
+									"description": "Zahel is <a target='_blank' href='https://coppermind.net/wiki/Vasher'>Vasher</a>. <a target='_blank' href='https://coppermind.net/wiki/Szeth'>Szeth</a>'s new <a target='_blank' href='https://coppermind.net/wiki/Shardblade'>Shardblade</a> is <a target='_blank' href='https://coppermind.net/wiki/Nightblood'>Nightblood</a>. <a target='_blank' href='https://coppermind.net/wiki/Mraize'>Mraize</a>'s collection in <a target='_blank' href='https://coppermind.net/wiki/Summary:Words_of_Radiance#Chapter_43:_The_Ghostbloods'>Chapter 43</a> includes a <a target='_blank' href='https://coppermind.net/wiki/Tears_of_Edgli'>Tear of Edgli</a> flower."
+								},
+								{
+									"target": "sa3",
+									"type": "major",
+									"description": "Azure is <a target='_blank' href='https://coppermind.net/wiki/Vivenna'>Vivenna</a>; she uses <a target='_blank' href='https://coppermind.net/wiki/Awakening'>Awakening</a> on several occaisions and has an Awakened sword. <a target='_blank' href='https://coppermind.net/wiki/Nightblood'>Nightblood</a> and <a target='_blank' href='https://coppermind.net/wiki/Vasher'>Vasher</a> make significant appearances. <a target='_blank' href='https://coppermind.net/wiki/Nightblood'>Nightblood</a> mentions <a target='_blank' href='https://coppermind.net/wiki/Denth'>Denth</a>, <a target='_blank' href='https://coppermind.net/wiki/Shashara'>Shashara</a>, and <a target='_blank' href='https://coppermind.net/wiki/Vivenna'>Vivenna</a> by name. A painting from the <a target='_blank' href='https://coppermind.net/wiki/Court_of_Gods'>Court of Gods</a> appears in <a target='_blank' href='https://coppermind.net/wiki/Summary:Oathbringer#Chapter_102:_Celebrant'>Chapter 102</a>. <a target='_blank' href='https://coppermind.net/wiki/Riino'>Riino</a> mentions <a target='_blank' href='https://coppermind.net/wiki/Heightening'>Heightenings</a>. <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> uses <a target='_blank' href='https://coppermind.net/wiki/Awakening'>Awakening</a> in the <a target='_blank' href='https://coppermind.net/wiki/Summary:Oathbringer#Epilogue:_Great_Art'>Epilogue</a>."
+								},
+								{
+									"target": "sa3.5",
+									"type": "minor",
+									"description": "The <a target='_blank' href='https://coppermind.net/wiki/Dawnshard'>Dawnshard</a> causes <a target='_blank' href='https://coppermind.net/wiki/Rysn_Ftori'>Rysn</a> to experience several effects similar to the <a target='_blank' href='https://coppermind.net/wiki/BioChromatic_Breath'>Heightenings associated with Breath</a>."
+								},
+								{
+									"target": "sa4",
+									"type": "major",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Nightblood'>Nightblood</a> is used to kill <a target='_blank' href='https://coppermind.net/wiki/Rayse'>Rayse</a>. <a target='_blank' href='https://coppermind.net/wiki/Ialai'>Ialai's</a> notes mention <a target='_blank' href='https://coppermind.net/wiki/Nalthis'>Nalthis</a>. <a target='_blank' href='https://coppermind.net/wiki/Zahel'>Zahel</a> uses <a target='_blank' href='https://coppermind.net/wiki/Awakening'>Awakening</a> in his fight against <a target='_blank' href='https://coppermind.net/wiki/Kaladin'>Kaladin</a> and explains that he is a <a target='_blank' href='https://coppermind.net/wiki/Cognitive_Shadow'>Cognitive Shadow</a>. The coin <a target='_blank' href='https://coppermind.net/wiki/Adolin'>Adolin</a> gives to <a target='_blank' href='https://coppermind.net/wiki/Kaladin'>Kaladin</a> and some merchants in <a target='_blank' href='https://coppermind.net/wiki/Lasting_Integrity'>Lasting Integrity</a> are from <a target='_blank' href='https://coppermind.net/wiki/Nalthis'>Nalthis</a>. <a target='_blank' href='https://coppermind.net/wiki/Endowment'>Endowment</a> is referenced in the <a target='_blank' href='https://coppermind.net/wiki/Rhythm_of_War/Epigraphs'>Chapter 24 epigraph</a>. <a target='_blank' href='https://coppermind.net/wiki/Odium'>Odium</a> tampers with <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid's</a> <a target='_blank' href='https://coppermind.net/wiki/BioChromatic_Breath'>Breath</a> in the Epilogue."
+								},
+								{
+									"target": "mb7",
+									"type": "minor",
+									"description": "(WIP) Nalthis is mentionned in chapter 39. Use of an Awakened lock in chapter 40."
+								}
+							]
+						},
+						{
+							"id": "nb",
+							"title": "Nightblood",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Nightblood_(book)'>Nightblood</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Nalthis'>Nalthis</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Nalthian_system'>Nalthian system</a>",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/87/#e5657'>This sequel occurs prior to The Stormlight Archive.</a>",
+							"sorting": {
+								"chronology": 5.2
+							},
+							"categories": [
+								"warbreaker",
+								"plan",
+								"unpublished",
+								"novel"
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"label": "Roshar",
+			"color": "#2aa1d4",
+			"children": [
+				{
+					"label": "The Stormlight Archive",
+					"children": [
+						{
+							"id": "sa1",
+							"title": "The Way of Kings",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Way_of_Kings'>The Way of Kings</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+							"publication": "August 2010",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/309/#e10273'>Occurs after Mistborn Era 1 and Warbreaker but before Mistborn Era 2.</a>",
+							"sorting": {
+								"order": 2.41,
+								"publication": 2010.08,
+								"chronology": 7.01
+							},
+							"appearances": [
+								{
+									"id": "hoid",
+									"type": "appearance",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is 'Wit'."
+								},
+								{
+									"id": "ars",
+									"type": "appearance"
+								}
+							],
+							"categories": [
+								"stormlight",
+								"phase2",
+								"published",
+								"novel"
+							]
+						},
+						{
+							"id": "sa2",
+							"title": "Words of Radiance",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Words_of_Radiance'>Words of Radiance</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+							"publication": "March 2014",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/309/#e10273'>Occurs after Mistborn Era 1 and Warbreaker but before Mistborn Era 2.</a>",
+							"sorting": {
+								"order": 2.42,
+								"publication": 2014.03,
+								"chronology": 7.02
+							},
+							"appearances": [
+								{
+									"id": "hoid",
+									"type": "appearance",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is 'Wit'."
+								},
+								{
+									"id": "nazh",
+									"type": "appearance",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> is the <a target='_blank' href='https://coppermind.net/wiki/Ardent'>ardent</a> trying to get a sketch of <a target='_blank' href='https://coppermind.net/wiki/Bridge_Four'>Bridge Four</a>'s tattoo in <a target='_blank' href='https://coppermind.net/wiki/Summary:Words_of_Radiance#Chapter_31:_The_Stillness_Before'>Chapter 31</a>. Several drawings and sketches also include his annotations."
+								},
+								{
+									"id": "ars",
+									"type": "appearance"
+								}
+							],
+							"categories": [
+								"stormlight",
+								"phase2",
+								"published",
+								"novel"
+							],
+							"connections": [
+								{
+									"target": "jasnah",
+									"type": "major",
+									"description": "A deleted scene about <a target='_blank' href='https://coppermind.net/wiki/Jasnah_Kholin'>Jasnah</a> that contains some canonical elements."
+								},
+								{
+									"target": "traveler",
+									"type": "minor",
+									"description": "The man <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> speaks with is <a target='_blank' href='https://coppermind.net/wiki/Frost'>Frost</a>, who responded to <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> with similar opinions in the <a target='_blank' href='https://coppermind.net/wiki/Words_of_Radiance/Epigraphs#The_Second_Letter'>Words of Radiance Part 4 epigraphs</a>."
+								},
+								{
+									"target": "au",
+									"type": "minor",
+									"description": "The <a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a> essay covers details about <a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a> and makes mentions of <a target='_blank' href='https://coppermind.net/wiki/Odium'>Odium</a>'s past."
+								},
+								{
+									"target": "mb7",
+									"type": "minor",
+									"description": "WIP"
+								}
+							]
+						},
+						{
+							"id": "sa2.5",
+							"title": "Edgedancer",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Edgedancer'>Edgedancer</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+							"au": "Included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
+							"padding": 12,
+							"publication": "November 2016",
+							"chronology": "Occurs after Words of Radiance and concurrently with the early events of Oathbringer.",
+							"sorting": {
+								"order": 2.43,
+								"publication": 2016.11,
+								"chronology": 7.025
+							},
+							"appearances": [
+								{
+									"id": "hoid",
+									"type": "mention",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is 'Ol' Whitehair', mentioned in <a target='_blank' href='https://coppermind.net/wiki/Summary:Edgedancer#Chapter_12'>Chapter 12</a>."
+								}
+							],
+							"categories": [
+								"stormlight",
+								"novella",
+								"phase2",
+								"published"
+							]
+						},
+						{
+							"id": "sa3",
+							"title": "Oathbringer",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Oathbringer'>Oathbringer</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+							"publication": "November 2017",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/309/#e10273'>Occurs after Mistborn Era 1 and Warbreaker but before Mistborn Era 2.</a>",
+							"sorting": {
+								"order": 2.44,
+								"publication": 2017.11,
+								"chronology": 7.03
+							},
+							"appearances": [
+								{
+									"id": "hoid",
+									"type": "appearance",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is 'Wit'."
+								},
+								{
+									"id": "nazh",
+									"type": "mention",
+									"description": "Several drawings and sketches include <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a>'s annotations. Most notably, the <a target='_blank' href='https://coppermind.net/wiki/Glyphs'>glyphs</a> page is entirely written by him."
+								},
+								{
+									"id": "ars",
+									"type": "appearance"
+								}
+							],
+							"categories": [
+								"stormlight",
+								"phase2",
+								"published",
+								"novel"
+							],
+							"connections": [
+								{
+									"target": "twokp",
+									"type": "minor",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/The_Way_of_Kings_Prime'>The Way of Kings Prime</a>, written in 2002, is the original draft of <a target='_blank' href='https://coppermind.net/wiki/The_Way_of_Kings'>The Way of Kings</a>. Only small excerpts were released prior to <a target='_blank' href='https://coppermind.net/wiki/The_Way_of_Kings'>Oathbringer</a> as Brandon felt it contained spoilers for certain ideas through that book. It was self-published as a Sanderson Curiosity in July 2020."
+								},
+								{
+									"target": "mb7",
+									"type": "minor",
+									"description": "WIP"
+								}
+							]
+						},
+						{
+							"id": "sa3.5",
+							"title": "Dawnshard",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Dawnshard_(novella)'>Dawnshard</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+							"publication": "November 2020",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/406/#e13986'>Between Oathbringer and Rhythm of War.</a>",
+							"padding": 12,
+							"sorting": {
+								"order": 2.45,
+								"publication": 2020.1105,
+								"chronology": 7.035
+							},
+							"categories": [
+								"stormlight",
+								"novella",
+								"published",
+								"phase2"
+							]
+						},
+						{
+							"id": "sa4",
+							"title": "Rhythm of War",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Rhythm_of_War'>Rhythm of War</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+							"publication": "November 2020",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/309/#e10273'>Occurs after Mistborn Era 1 and Warbreaker but before Mistborn Era 2.</a>",
+							"sorting": {
+								"order": 2.46,
+								"publication": 2020.1117,
+								"chronology": 7.04
+							},
+							"appearances": [
+								{
+									"id": "hoid",
+									"type": "appearance",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is 'Wit'."
+								},
+								{
+									"id": "nazh",
+									"type": "mention",
+									"description": "Several drawings and sketches include <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a>'s annotations. Most notably, the <a target='_blank' href='https://coppermind.net/wiki/Glyphs'>glyphs</a> page is entirely written by him."
+								},
+								{
+									"id": "ars",
+									"type": "appearance"
+								}
+							],
+							"categories": [
+								"stormlight",
+								"novel",
+								"phase2",
+								"published"
+							],
+							"connections": [
+								{
+									"target": "d1",
+									"type": "egg",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Microkinesis'>Microkinesis</a> referes to a type of magic from <a target='_blank' href='https://coppermind.net/wiki/Yolen'>Yolen</a> in <a target='_blank' href='https://coppermind.net/wiki/Dragonsteel'>Dragonsteel</a>."
+								},
+								{
+									"target": "mb2",
+									"type": "minor",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Ati'>Ati</a> speaks to <a target='_blank' href='https://coppermind.net/wiki/Vin'>Vin</a> and others with <a target='_blank' href='https://coppermind.net/wiki/Ruin'>Ruin's</a> <a target='_blank' href='https://coppermind.net/wiki/Rhythm#The_Pure_Tones'>Pure Tone</a>. The <a target='_blank' href='https://coppermind.net/wiki/Well_of_Ascension'>Well of Ascension</a> pulses with <a target='_blank' href='https://coppermind.net/wiki/Preservation'>Preservation's</a> <a target='_blank' href='https://coppermind.net/wiki/Rhythm#The_Pure_Tones'>Pure Tone</a>"
+								},
+								{
+									"target": "mb7",
+									"type": "significant",
+									"description": "WIP"
+								}
+							]
+						},
+						{
+							"id": "sa4.5",
+							"title": "Horneater (2023)",
+							"title2": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2019/'>Horneater</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+							"padding": 12,
+							"chronology": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>Fills in what happened with Rock after the events of Rhythm of War.</a>",
+							"sorting": {
+								"publication": 2023.11,
+								"chronology": 7.045
+							},
+							"categories": [
+								"stormlight",
+								"novella",
+								"plan",
+								"unpublished"
+							]
+						},
+						{
+							"id": "sa5",
+							"title": "Stormlight Archive 5 (2024)",
+							"title2": "Stormlight Archive 5",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+							"publication": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>Fall 2023</a>",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/309/#e10273'>Occurs after Mistborn Era 1 and Warbreaker but before Mistborn Era 2.</a>",
+							"sorting": {
+								"publication": 2023.11,
+								"chronology": 7.05
+							},
+							"categories": [
+								"stormlight",
+								"plan",
+								"forthcoming",
+								"novel"
+							]
+						},
+						{
+							"id": "lopen",
+							"title": "King Lopen the First",
+							"title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=king+lopen+the+first+of+alethkar'>King Lopen the First of Alethkar</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/31/#e1703'>Occurs concurrently with the final events of Words of Radiance.</a>",
+							"padding": 12,
+							"sorting": {
+								"chronology": 7.022
+							},
+							"categories": [
+								"stormlight",
+								"short",
+								"plan",
+								"unpublished"
+							]
+						},
+						{
+							"id": "tdatd",
+							"title": "The Dog and the Dragon",
+							"title2": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>The Dog and the Dragon picture book</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+							"padding": 12,
+							"categories": [
+								"stormlight",
+								"plan",
+								"unpublished",
+								"graphic"
+							]
+						},
+						{
+							"id": "tgwlu",
+							"title": "The Girl Who Looked Up",
+							"title2": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>The Girl Who Looked Up picture book</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+							"padding": 12,
+							"categories": [
+								"stormlight",
+								"plan",
+								"unpublished",
+								"graphic"
+							]
+						},
+						{
+							"id": "sa-art",
+							"title": "Stormlight Archive art book",
+							"title2": "<a target='_blank' href='https://wob.coppermind.net/events/396/#e13175'>Stormlight Archive art book</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+							"padding": 12,
+							"categories": [
+								"stormlight",
+								"plan",
+								"unpublished",
+								"graphic"
+							]
+						},
+						{
+							"id": "sa6",
+							"title": "Stormlight Archive 6",
+							"title2": "Stormlight Archive 6",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/61/#e1300'>There's a roughly 15 year gap between Stormlight 5 and 6.</a> <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>Occurs after Mistborn Era 2 and before Mistborn Era 3.</a>",
+							"publication": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>2028 (best guess)</a>",
+							"sorting": {
+								"chronology": 9.06,
+								"publication": 2028
+							},
+							"categories": [
+								"stormlight",
+								"plan",
+								"unpublished",
+								"novel"
+							]
+						},
+						{
+							"id": "sa7",
+							"title": "Stormlight Archive 7",
+							"title2": "Stormlight Archive 7",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/61/#e1300'>There's a roughly 15 year gap between Stormlight 5 and 6.</a> <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>Occurs after Mistborn Era 2 and before Mistborn Era 3.</a>",
+							"sorting": {
+								"chronology": 9.07
+							},
+							"categories": [
+								"stormlight",
+								"plan",
+								"unpublished",
+								"novel"
+							]
+						},
+						{
+							"id": "sa8",
+							"title": "Stormlight Archive 8",
+							"title2": "Stormlight Archive 8",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/61/#e1300'>There's a roughly 15 year gap between Stormlight 5 and 6.</a> <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>Occurs after Mistborn Era 2 and before Mistborn Era 3.</a>",
+							"sorting": {
+								"chronology": 9.08
+							},
+							"categories": [
+								"stormlight",
+								"plan",
+								"unpublished",
+								"novel"
+							]
+						},
+						{
+							"id": "sa9",
+							"title": "Stormlight Archive 9",
+							"title2": "Stormlight Archive 9",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/61/#e1300'>There's a roughly 15 year gap between Stormlight 5 and 6.</a> <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>Occurs after Mistborn Era 2 and before Mistborn Era 3.</a>",
+							"sorting": {
+								"chronology": 9.09
+							},
+							"categories": [
+								"stormlight",
+								"plan",
+								"unpublished",
+								"novel"
+							]
+						},
+						{
+							"id": "sa10",
+							"title": "Stormlight Archive 10",
+							"title2": "Stormlight Archive 10",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/61/#e1300'>There's a roughly 15 year gap between Stormlight 5 and 6.</a> <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>Occurs after Mistborn Era 2 and before Mistborn Era 3.</a>",
+							"sorting": {
+								"chronology": 9.1
+							},
+							"categories": [
+								"stormlight",
+								"plan",
+								"unpublished",
+								"novel"
+							],
+							"connections": [
+								{
+									"target": "sotd2",
+									"type": "minor",
+									"description": "A <a target='_blank' href='https://coppermind.net/wiki/Knights_Radiant'>Knight Radiant</a> makes an appearance, weilding a 'Shardgun'."
+								}
+							]
+						}
+					]
+				},
+				{
+					"children": [
+						{
+							"id": "tsd",
+							"title": "The Silence Divine",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Silence_Divine'>The Silence Divine</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Ashyn'>Ashyn</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+							"link": "<a target='_blank' href='https://wob.coppermind.net/events/201/#e12303'>Excerpt on Arcanum.</a>",
+							"publication": "March 2014",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/370/#e11901'>Occurs late in the Stormlight Archive era, around book 8.</a>",
+							"sorting": {
+								"publication": 2014.03,
+								"chronology": 9.081
+							},
+							"categories": [
+								"no-series",
+								"plan",
+								"unpublished",
+								"novella"
+							],
+							"connections": [
+								{
+									"target": "sa3",
+									"type": "minor",
+									"description": "The Silence Divine is set on <a target='_blank' href='https://coppermind.net/wiki/Ashyn'>Ashyn</a>, the world that the humans fled to <a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a> from."
+								}
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"label": "Taldain",
+			"color": "#d4c955",
+			"children": [
+				{
+					"label": "White Sand",
+					"children": [
+						{
+							"id": "ws1",
+							"title": "White Sand Volume 1",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/White_Sand_Volume_1'>White Sand Volume 1</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/White_Sand'>White Sand</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Taldain_system'>Taldain system</a>",
+							"au": "Excerpt included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
+							"publication": "June 2016",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/182/#e3878'>White Sand occurs prior to Elantris.</a>",
+							"sorting": {
+								"order": 2.11,
+								"publication": 2016.06,
+								"chronology": 2.1
+							},
+							"appearances": [
+								{
+									"id": "hoid",
+									"type": "appearance",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is the hooded man with a stringed instrument who first appears in <a target='_blank' href='https://coppermind.net/wiki/Ais'>Ais</a>'s first scene in the middle of <a target='_blank' href='https://coppermind.net/wiki/Summary:White_Sand_Volume_1#Chapter_4:_Divides'>Chapter 4</a>."
+								},
+								{
+									"id": "khriss",
+									"type": "appearance",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> is a main character."
+								}
+							],
+							"categories": [
+								"white-sand",
+								"phase2b",
+								"published",
+								"graphic"
+							],
+							"connections": [
+								{
+									"target": "mb1",
+									"type": "egg",
+									"description": "'Kenton Street' in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Well_of_Ascension#Chapter_17'>Chapter 17</a> (also mentioned in <a target='_blank' href='https://coppermind.net/wiki/The_Well_of_Ascension'>The Well of Ascension) is a reference to <a target='_blank' href='https://coppermind.net/wiki/Kenton'>Kenton</a>."
+								},
+								{
+									"target": "sa2",
+									"type": "egg",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Mraize'>Mraize</a>'s collection in <a target='_blank' href='https://coppermind.net/wiki/Summary:Words_of_Radiance#Chapter_43:_The_Ghostbloods'>Chapter 43</a> includes a vial of sand from <a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a>."
+								},
+								{
+									"target": "au",
+									"type": "minor",
+									"description": "The <a target='_blank' href='https://coppermind.net/wiki/Taldain_system'>Taldain system</a> essay discusses <a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a> and <a target='_blank' href='https://coppermind.net/wiki/Sand_mastery'>sand mastery</a>."
+								},
+								{
+									"target": "sa4",
+									"type": "minor",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a> is referenced in <a target='_blank' href='https://coppermind.net/wiki/Ialai'>Ialai's</a> notes."
+								},
+								{
+									"target": "mb7",
+									"type": "egg",
+									"description": "(WIP) Taldain is Autonomy's original planet. Aether manipulation drains the body's water supply like Sand mastery."
+								}
+							]
+						},
+						{
+							"id": "ws2",
+							"title": "White Sand Volume 2",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/White_Sand_Volume 2'>White Sand Volume 2</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/White_Sand'>White Sand</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Taldain_system'>Taldain system</a>",
+							"publication": "February 2018",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/182/#e3878'>White Sand occurs prior to Elantris.</a>",
+							"sorting": {
+								"order": 2.12,
+								"publication": 2018.02,
+								"chronology": 2.2
+							},
+							"appearances": [
+								{
+									"id": "hoid",
+									"type": "appearance",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is the hooded man with a stringed instrument."
+								},
+								{
+									"id": "khriss",
+									"type": "appearance",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> is a main character."
+								}
+							],
+							"categories": [
+								"white-sand",
+								"phase2b",
+								"published",
+								"graphic"
+							],
+							"connections": [
+								{
+									"target": "mb1",
+									"type": "minor",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Trell_(Taldain)'>Trell the foreman</a> is connected to <a target='_blank' href='https://coppermind.net/wiki/Trelagism'>Trelagism</a>."
+								},
+								{
+									"target": "mb4",
+									"type": "significant",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Trell_(Taldain)'>Trell the foreman</a> is connected to the god <a target='_blank' href='https://coppermind.net/wiki/Trellism'>Trell</a>."
+								},
+								{
+									"target": "sa3",
+									"type": "egg",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Wit</a> has a jar of black sand from <a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a> in <a target='_blank' href='https://coppermind.net/wiki/Summary:Oathbringer#Chapter_67:_Mishim'>Chapter 67</a>, which turns white after <a target='_blank' href='https://coppermind.net/wiki/Shallan'>Shallan</a> <a target='_blank' href='https://coppermind.net/wiki/Lightweaving'>Lightweaves</a>."
+								},
+								{
+									"target": "sa4",
+									"type": "minor",
+									"description": "Sand from <a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a> is used to identify and quantify <a target='_blank' href='https://coppermind.net/wiki/Investiture'>kinetic Investiture</a>, including explicit mention of the fauna which makes the sand special."
+								}
+							]
+						},
+						{
+							"id": "ws3",
+							"title": "White Sand Volume 3",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/White_Sand_Volume_3'>White Sand Volume 3</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/White_Sand'>White Sand</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Taldain_system'>Taldain system</a>",
+							"publication": "October 2019",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/182/#e3878'>White Sand occurs prior to Elantris.</a>",
+							"sorting": {
+								"order": 2.13,
+								"publication": 2019.1,
+								"chronology": 2.3
+							},
+							"appearances": [
+								{
+									"id": "hoid",
+									"type": "appearance",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is the hooded man with a stringed instrument who plays a song in the <a target='_blank' href='https://coppermind.net/wiki/Summary:White_Sand_Volume_3#Epilogue'>Epilogue</a>."
+								},
+								{
+									"id": "khriss",
+									"type": "appearance",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> is a main character."
+								}
+							],
+							"categories": [
+								"white-sand",
+								"phase2b",
+								"published",
+								"graphic"
+							],
+							"connections": [
+								{
+									"target": "sa1",
+									"type": "egg",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Baon'>Baon</a> appears in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Way_of_Kings#Interlude_I-1:_Ishikk'>Interlude I-1</a> as 'Blunt'."
+								}
+							]
+						}
+					]
+				},
+				{
+					"label": "The Arcanist",
+					"children": [
+						{
+							"id": "ta1",
+							"title": "The Arcanist Volume 1",
+							"title2": "The Arcanist Volume 1",
+							"series": "The Arcanist (citation needed)",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Taldain_system'>Taldain system</a>",
+							"chronology": "Described as a sequel, so presumably occurs shortly after White Sand.",
+							"sorting": {
+								"chronology": 2.5
+							},
+							"categories": [
+								"white-sand",
+								"plan",
+								"unpublished",
+								"graphic"
+							]
+						},
+						{
+							"id": "ta2",
+							"title": "The Arcanist Volume 2",
+							"title2": "The Arcanist Volume 2",
+							"series": "The Arcanist (citation needed)",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Taldain_system'>Taldain system</a>",
+							"chronology": "Described as a sequel, so presumably occurs shortly after White Sand.",
+							"sorting": {
+								"chronology": 2.6
+							},
+							"categories": [
+								"white-sand",
+								"plan",
+								"unpublished",
+								"graphic"
+							]
+						},
+						{
+							"id": "ta3",
+							"title": "The Arcanist Volume 3",
+							"title2": "The Arcanist Volume 3",
+							"series": "The Arcanist (citation needed)",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Taldain_system'>Taldain system</a>",
+							"chronology": "Described as a sequel, so presumably occurs shortly after White Sand.",
+							"sorting": {
+								"chronology": 2.7
+							},
+							"categories": [
+								"white-sand",
+								"plan",
+								"unpublished",
+								"graphic"
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"label": "Threnody",
+			"color": "#6633cc",
+			"children": [
+				{
+					"children": [
+						{
+							"id": "sfs",
+							"title": "Shadows for Silence",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Shadows_for_Silence_in_the_Forests_of_Hell'>Shadows for Silence in the Forests of Hell</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Threnody'>Threnody</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Threnodite_system'>Threnodite system</a>",
+							"au": "Included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
+							"publication": "December 2013",
+							"chronology": "Occurs <a target='_blank' href='https://wob.coppermind.net/events/216/#e6445'>before Stormlight Archive</a> but <a target='_blank' href='https://wob.coppermind.net/events/309/#e10273'>after Warbreaker</a>.",
+							"sorting": {
+								"order": 1.5,
+								"publication": 2013.12,
+								"chronology": 6.1
+							},
+							"categories": [
+								"no-series",
+								"novella",
+								"phase1b",
+								"published"
+							],
+							"connections": [
+								{
+									"target": "sa2",
+									"type": "egg",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Mraize'>Mraize</a>'s collection in <a target='_blank' href='https://coppermind.net/wiki/Summary:Words_of_Radiance#Chapter_43:_The_Ghostbloods'>Chapter 43</a> includes a silver knife from <a target='_blank' href='https://coppermind.net/wiki/Threnody'>Threnody</a>."
+								},
+								{
+									"target": "sa3",
+									"type": "egg",
+									"description": "The silvery chain in <a target='_blank' href='https://coppermind.net/wiki/Celebrant'>Celebrant</a> is from <a target='_blank' href='https://coppermind.net/wiki/Threnody'>Threnody</a>."
+								},
+								{
+									"target": "msh",
+									"type": "minor",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Kelsier'>Kelsier</a> causes the <a target='_blank' href='https://coppermind.net/wiki/Ire'>Ire</a> to suspect <a target='_blank' href='https://coppermind.net/wiki/Shade'>Shades</a> from <a target='_blank' href='https://coppermind.net/wiki/Threnody'>Threnody</a> are nearby."
+								},
+								{
+									"target": "au",
+									"type": "minor",
+									"description": "The <a target='_blank' href='https://coppermind.net/wiki/Threnodite_system'>Threnodite system</a> essay discusses the history of <a target='_blank' href='https://coppermind.net/wiki/Threnody'>Threnody</a>."
+								},
+								{
+									"target": "sa4",
+									"type": "egg",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Raboniel'>Raboniel's</a> chain from 'the lands of the dead' is likely a <a target='_blank' href='https://coppermind.net/wiki/Silver'>silver</a> chain from <a target='_blank' href='https://coppermind.net/wiki/Threnody'>Threnody</a>."
+								}
+							]
+						}
+					]
+				},
+				{
+					"children": [
+						{
+							"id": "db",
+							"title": "The Dust Brigade",
+							"title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=the+dust+brigade'>The Dust Brigade</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Threnody'>Threnody</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Threnodite_system'>Threnodite system</a>",
+							"categories": [
+								"no-series",
+								"plan",
+								"unpublished",
+								"novel"
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"label": "First of<br>the Sun",
+			"color": "#367485",
+			"children": [
+				{
+					"children": [
+						{
+							"id": "sotd",
+							"title": "Sixth of the Dusk",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Sixth_of_the_Dusk'>Sixth of the Dusk</a>",
+							"series": "Sixth of<br>the Dusk",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/First_of_the_Sun'>First of the Sun</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Drominad_system'>Drominad system</a>",
+							"au": "Included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
+							"publication": "June 2014",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/60/#e6664'>Shortly before Mistborn Era 4.</a>",
+							"sorting": {
+								"order": 1.6,
+								"publication": 2014.06,
+								"chronology": 13.0
+							},
+							"categories": [
+								"no-series",
+								"novella",
+								"phase1b",
+								"published"
+							],
+							"connections": [
+								{
+									"target": "sa3",
+									"type": "minor",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Mraize'>Mraize</a>'s chicken, mentioned in <a target='_blank' href='https://coppermind.net/wiki/Summary:Oathbringer#Chapter_22:_The_Darkness_Within'>Chapter 22</a>, is an <a target='_blank' href='https://coppermind.net/wiki/Aviar'>Aviar</a>. <a target='_blank' href='https://coppermind.net/wiki/Patji'>Patji</a> is referenced obliquely in <a target='_blank' href='https://coppermind.net/wiki/Autonomy'>Autonomy</a>'s <a target='_blank' href='https://coppermind.net/wiki/Letters#Second_Oathbringer_Letter'>letter</a> to <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> in the <a target='_blank' href='https://coppermind.net/wiki/Oathbringer/Epigraphs#Letters'>Part 2 epigraphs</a>."
+								},
+								{
+									"target": "au",
+									"type": "minor",
+									"description": "The <a target='_blank' href='https://coppermind.net/wiki/Drominad_system'>Drominad system</a> essay discusses <a target='_blank' href='https://coppermind.net/wiki/First_of_the_Sun'>First of the Sun</a> and its magic."
+								},
+								{
+									"target": "sa4",
+									"type": "minor",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Gereh'>Gereh</a> has an <a target='_blank' href='https://coppermind.net/wiki/Aviar'>Aviar</a>, which <a target='_blank' href='https://coppermind.net/wiki/Lift'>Lift</a> comes into possession of."
+								}
+							]
+						},
+						{
+							"id": "sotd2",
+							"title": "Sixth of the Dusk sequel",
+							"title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=sixth+of+the+dusk+sequel'>Sixth of the Dusk sequel</a>",
+							"series": "Sixth of<br>the Dusk",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/First_of_the_Sun'>First of the Sun</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Drominad_system'>Drominad system</a>",
+							"chronology": "Five years after Sixth of the Dusk.",
+							"sorting": {
+								"chronology": 13.02
+							},
+							"link": "<a target='_blank' href='https://wob.coppermind.net/events/448/#e14408'>Excerpt on Arcanum.</a> (some may consider to be spoilers)",
+							"categories": [
+								"no-series",
+								"novella",
+								"plan",
+								"unpublished"
+							]
+						}
+					]
+				},
+				{
+					"children": [
+						{
+							"id": "kingmaker",
+							"title": "Kingmaker",
+							"title2": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>Kingmaker</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/First_of_the_Sun'>First of the Sun</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Drominad_system'>Drominad system</a>",
+							"link": "<a target='_blank' href='https://wob.coppermind.net/events/479/#e15153'>Reading on Arcanum.</a>",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/479/#e15153'>The reading suggests a setting not long after Sixth of the Dusk.</a>",
+							"sorting": {
+								"chronology": 13.01
+							},
+							"categories": [
+								"no-series",
+								"novel",
+								"plan",
+								"unpublished"
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"label": "Yolen",
+			"color": "#d98a41",
+			"children": [
+				{
+					"label": "Dragonsteel",
+					"children": [
+						{
+							"id": "d1",
+							"title": "Dragonsteel 1",
+							"title2": "Dragonsteel 1",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/Dragonsteel'>Dragonsteel</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Yolen'>Yolen</a>",
+							"system": "Yolish system",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/103/#e1024'>Dragonsteel is the first series in the cosmere storyline.</a>",
+							"sorting": {
+								"chronology": 1.1
+							},
+							"categories": [
+								"dragonsteel",
+								"plan",
+								"unpublished",
+								"novel"
+							],
+							"connections": [
+								{
+									"target": "mb7",
+									"type": "egg",
+									"description": "(WIP) A Sho Del is described in the epilogue."
+								}
+							]
+						},
+						{
+							"id": "d2",
+							"title": "Dragonsteel 2",
+							"title2": "Dragonsteel 2",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/Dragonsteel'>Dragonsteel</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Yolen'>Yolen</a>",
+							"system": "Yolish system",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/103/#e1024'>Dragonsteel is the first series in the cosmere storyline.</a>",
+							"sorting": {
+								"chronology": 1.2
+							},
+							"categories": [
+								"dragonsteel",
+								"plan",
+								"unpublished",
+								"novel"
+							]
+						},
+						{
+							"id": "d3",
+							"title": "Dragonsteel 3",
+							"title2": "Dragonsteel 3",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/Dragonsteel'>Dragonsteel</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Yolen'>Yolen</a>",
+							"system": "Yolish system",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/103/#e1024'>Dragonsteel is the first series in the cosmere storyline.</a>",
+							"sorting": {
+								"chronology": 1.3
+							},
+							"categories": [
+								"dragonsteel",
+								"plan",
+								"unpublished",
+								"novel"
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"label": "Other",
+			"color": "#a0a0a0",
+			"children": [
+				{
+					"label": "Aether<br>Series",
+					"color": "#e3a1e3",
+					"children": [
+						{
+							"id": "aether1",
+							"title": "Aether Book 1",
+							"title2": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2019/'>Aether Book 1</a>",
+							"world": "Unknown",
+							"system": "Unknown",
+							"categories": [
+								"aether",
+								"novel",
+								"plan",
+								"unpublished"
+							]
+						},
+						{
+							"id": "aether2",
+							"title": "Aether Book 2",
+							"title2": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2019/'>Aether Book 2</a>",
+							"world": "Unknown",
+							"system": "Unknown",
+							"categories": [
+								"aether",
+								"novel",
+								"plan",
+								"unpublished"
+							]
+						},
+						{
+							"id": "aether3",
+							"title": "Aether Book 3",
+							"title2": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2019/'>Aether Book 3</a>",
+							"world": "Unknown",
+							"system": "Unknown",
+							"categories": [
+								"aether",
+								"novel",
+								"plan",
+								"unpublished"
+							]
+						}
+					]
+				},
+				{
+					"children": [
+						{
+							"id": "secret1",
+							"title": "Secret Project 1 (2023)",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Secret_Project_One'>Secret Project 1</a>",
+							"world": "Spoiler",
+							"system": "Spoiler",
+							"publication": "January 2023",
+							"sorting": {
+								"publication": 2023.01
+							},
+							"link": "Chapters 1-5 available on <a target='_blank' href='brandonsanderson.com/first-look-at-secret-project-1'>Brandon's website</a> and <a target='_blank' href='https://youtu.be/bBUVXcIE0E0'>YouTube</a>. (some may consider to be spoilers)",
+							"categories": [
+								"no-series",
+								"novel",
+								"plan",
+								"forthcoming"
+							]
+						}
+					]
+				},
+				{
+					"children": [
+						{
+							"id": "secret3",
+							"title": "Secret Project 3 (2023)",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Secret_Project_Three'>Secret Project 3</a>",
+							"world": "Spoiler",
+							"system": "Spoiler",
+							"publication": "July 2023",
+							"sorting": {
+								"publication": 2023.07
+							},
+							"link": "Chapters 1-7 available on <a target='_blank' href='brandonsanderson.com/first-look-at-secret-project-3'>Brandon's website</a> and <a target='_blank' href='https://youtu.be/cFGDcvtRdz0'>YouTube</a>. (some may consider to be spoilers)",
+							"categories": [
+								"no-series",
+								"novel",
+								"plan",
+								"forthcoming"
+							]
+						}
+					]
+				},
+				{
+					"children": [
+						{
+							"id": "secret4",
+							"title": "Secret Project 4 (2023)",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Secret_Project_Four'>Secret Project 4</a>",
+							"world": "Spoiler",
+							"system": "Spoiler",
+							"publication": "October 2023",
+							"sorting": {
+								"publication": 2023.1
+							},
+							"categories": [
+								"no-series",
+								"novel",
+								"plan",
+								"forthcoming"
+							]
+						}
+					]
+				},
+				{
+					"children": [
+						{
+							"id": "silverlight",
+							"title": "Silverlight novella",
+							"title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=silverlight+novella'>Silverlight novella</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Cognitive_Realm'>Cognitive Realm</a>",
+							"system": "N/A",
+							"categories": [
+								"no-series",
+								"novella",
+								"plan",
+								"unpublished"
+							]
+						}
+					]
+				},
+				{
+					"children": [
+						{
+							"id": "kite",
+							"title": "Magic Kites YA story",
+							"title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=kite+magic'>Kite-based magic story</a>",
+							"world": "Unknown",
+							"system": "Unknown",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/379/#e12466'>Planned to take place between Mistborn Era 3 and 4.</a>",
+							"sorting": {
+								"chronology": 11.0
+							},
+							"categories": [
+								"no-series",
+								"novella",
+								"plan",
+								"unpublished"
+							]
+						}
+					]
+				},
+				{
+					"children": [
+						{
+							"id": "au",
+							"title": "Arcanum Unbounded (essays)",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded (essays)</a>",
+							"world": "N/A",
+							"system": "N/A",
+							"au": "Included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
+							"publication": "November 2016",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/36/#e1491'>The essays were written before the events of Sixth of the Dusk.</a> They could potentially be as early as Mistborn Era 3.",
+							"sorting": {
+								"order": 2.3,
+								"publication": 2016.11,
+								"chronology": 12.0
+							},
+							"appearances": [
+								{
+									"id": "khriss",
+									"type": "mention",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> is the author of the essays."
+								}
+							],
+							"categories": [
+								"no-series",
+								"short",
+								"phase2",
+								"published"
+							],
+							"connections": [
+								{
+									"target": "sa4",
+									"type": "minor",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Devotion'>Devotion</a> and <a target='_blank' href='https://coppermind.net/wiki/Dominion'>Dominion</a> are referenced in the <a target='_blank' href='https://coppermind.net/wiki/Rhythm_of_War/Epigraphs'>Chapter 26 Epigraph</a>. <a target='_blank' href='https://coppermind.net/wiki/Ambition'>Ambition's</a> struggle with <a target='_blank' href='https://coppermind.net/wiki/Odium'>Odium</a> is referenced in the <a target='_blank' href='https://coppermind.net/wiki/Rhythm_of_War/Epigraphs'>Chapter 27 Epigraph</a>."
+								},
+								{
+									"target": "mb7",
+									"type": "minor",
+									"description": "WIP"
+								}
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"label": "Mixed",
+			"color": "#a0a0a0",
+			"children": [
+				{
+					"children": [
+						{
+							"id": "wsp",
+							"title": "White Sand (prose)",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/White_Sand_(prose)'>White Sand (prose)</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Taldain_system'>Taldain system</a>",
+							"au": "Excerpt included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded.</a>.",
+							"link": "<a target='_blank' href='https://brandonsanderson.com/newsletter-signup/'>Link to full text found in Brandon's newsletter.</a>",
+							"publication": "June 2009 (upon request)",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/182/#e3878'>White Sand occurs prior to Elantris.</a>",
+							"sorting": {
+								"order": 2.14,
+								"publication": 2009.06,
+								"chronology": 2.0
+							},
+							"appearances": [
+								{
+									"id": "khriss",
+									"type": "appearance",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> is a main character."
+								}
+							],
+							"categories": [
+								"white-sand",
+								"novel",
+								"apocryphal",
+								"noncanon"
+							],
+							"connections": [
+								{
+									"target": "ws1",
+									"type": "minor",
+									"description": "The <a target='_blank' href='https://coppermind.net/wiki/White_Sand'>White Sand</a> graphic novels are based on the prose version."
+								}
+							]
+						},
+						{
+							"id": "aon",
+							"title": "Aether of Night",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Aether_of_Night'>Aether of Night</a>",
+							"world": "Unknown",
+							"system": "Unknown",
+							"link": "<a target='_blank' href='https://www.17thshard.com/forum/topic/60219-aether-of-night-manuscript-requests/'>Full text available from the 17th Shard.</a>",
+							"publication": "June 2009 (upon request)",
+							"sorting": {
+								"order": 2.92,
+								"publication": 2009.06
+							},
+							"categories": [
+								"no-series",
+								"apocryphal",
+								"noncanon",
+								"novel"
+							],
+							"connections": [
+								{
+									"target": "sa2",
+									"type": "egg",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Mraize'>Mraize</a>'s collection in <a target='_blank' href='https://coppermind.net/wiki/Summary:Words_of_Radiance#Chapter_43:_The_Ghostbloods'>Chapter 43</a> includes pink <a target='_blank' href='https://coppermind.net/wiki/Aether'>aether</a>."
+								},
+								{
+									"target": "sa3",
+									"type": "egg",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Mraize'>Mraize</a> mentions his suit was stained with <a target='_blank' href='https://coppermind.net/wiki/Aether'>aether</a>."
+								},
+								{
+									"target": "sa4",
+									"type": "egg",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Foil'>Foil</a> is said to be seeking 'control over the <a target='_blank' href='https://coppermind.net/wiki/Aether'>aethers</a>'."
+								},
+								{
+									"target": "mb7",
+									"type": "minor",
+									"description": "(WIP) TwinSoul can manipulates the Aethers."
+								}
+							]
+						},
+						{
+							"id": "imperial-fool",
+							"title": "Imperial Fool",
+							"title2": "Imperial Fool",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Sel'>Sel</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Selish_system'>Selish system</a>",
+							"link": "<a target='_blank' href='https://brandonsanderson.com/the-emperors-soul-deleted-prologue-imperial-fool'>Full text on Brandon's website.</a>",
+							"publication": "November 2012",
+							"chronology": "Concerns events shortly before the events of The Emperor's Soul.",
+							"sorting": {
+								"order": 1.41,
+								"publication": 2012.11,
+								"chronology": 3.4
+							},
+							"appearances": [
+								{
+									"id": "hoid",
+									"type": "appearance",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is the 'Imperial Fool'."
+								}
+							],
+							"categories": [
+								"no-series",
+								"short",
+								"apocryphal",
+								"noncanon"
+							]
+						},
+						{
+							"id": "twokp",
+							"title": "The Way of Kings Prime",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Way_of_Kings_Prime'>The Way of Kings Prime</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+							"link": "<a target='_blank' href='https://www.brandonsanderson.com/the-way-of-kings-prime/'>Full novel on Brandon's website.</a>",
+							"publication": "July 2020",
+							"sorting": {
+								"order": 2.91,
+								"publication": 2020.07
+							},
+							"categories": [
+								"stormlight",
+								"novel",
+								"apocryphal",
+								"noncanon"
+							]
+						},
+						{
+							"id": "jasnah",
+							"title": "Jasnah deleted scene",
+							"title2": "Jasnah deleted scene",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+							"link": "<a target='_blank' href='https://www.tor.com/2014/08/06/stormlight-archive-scene-after-words-of-radiance'>Full text on Tor.com.</a>",
+							"publication": "August 2014",
+							"chronology": "Occurs during the early events of Words of Radiance.",
+							"sorting": {
+								"order": 2.421,
+								"publication": 2014.08,
+								"chronology": 7.021
+							},
+							"categories": [
+								"stormlight",
+								"short",
+								"apocryphal",
+								"noncanon"
+							]
+						},
+						{
+							"id": "traveler",
+							"title": "The Traveler",
+							"title2": "The Traveler",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Yolen'>Yolen</a>",
+							"system": "Yolish system",
+							"link": "<a target='_blank' href='https://wob.coppermind.net/events/332/#e9518'>Full text on Arcanum.</a>",
+							"publication": "April 2018",
+							"chronology": "Occurs shortly after Mistborn Era 1.",
+							"sorting": {
+								"order": 2.26,
+								"publication": 2018.04,
+								"chronology": 4.5
+							},
+							"appearances": [
+								{
+									"id": "hoid",
+									"type": "appearance",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is 'the Traveler'."
+								}
+							],
+							"categories": [
+								"no-series",
+								"short",
+								"apocryphal",
+								"noncanon"
+							]
+						}
+					]
+				}
+			]
+		}
+	]
 }

--- a/public/data.json
+++ b/public/data.json
@@ -1,2505 +1,2142 @@
 {
-	"base-separation": 3.21,
-	"connections": [
-		{
-			"id": "major",
-			"description": "Major Connections",
-			"details": "There is at least one major connection between the books which will enhance your understanding of the plot and the Cosmere. Reading in this order is highly recommended, and reading out of order may be spoilery.",
-			"color": "#770000",
-			"highlightColor": "#DB1E1E",
-			"width": 2
-		},
-		{
-			"id": "significant",
-			"description": "Significant Connections",
-			"details": "There is at least one significant connection between the books which may enhance your understanding of the plot and the Cosmere. Reading in this order is recommended.",
-			"color": "#a0470d",
-			"highlightColor": "#a0470d",
-			"width": 2,
-			"dash": "4 2"
-		},
-		{
-			"id": "minor",
-			"description": "Minor Connections",
-			"details": "There is at least one minor connection between the books which may enhance your understanding of the plot and Cosmere in a small way.",
-			"color": "#a09713",
-			"highlightColor": "#a09713",
-			"width": 1,
-			"dash": "3",
-			"activeByDefault": false
-		},
-		{
-			"id": "egg",
-			"description": "Easter Eggs",
-			"details": "There is at least one subtle reference between the books which may hint at something bigger going on. Easter eggs may be very difficult to spot unaided.",
-			"color": "#4d4d4d",
-			"highlightColor": "#4d4d4d",
-			"width": 1,
-			"dash": "2",
-			"activeByDefault": false
-		}
-	],
-	"layers": [
-		{
-			"id": "pub-status",
-			"name": "Publication Status",
-			"categories": [
+    "base-separation": 3.21,
+    "connections": [
+        {
+            "id": "major",
+            "description": "Major Connections",
+            "details": "There is at least one major connection between the books which will enhance your understanding of the plot and the Cosmere. Reading in this order is highly recommended, and reading out of order may be spoilery.",
+            "color": "#770000",
+            "highlightColor": "#DB1E1E",
+            "width": 2
+        },
+        {
+            "id": "significant",
+            "description": "Significant Connections",
+            "details": "There is at least one significant connection between the books which may enhance your understanding of the plot and the Cosmere. Reading in this order is recommended.",
+            "color": "#a0470d",
+            "highlightColor": "#a0470d",
+            "width": 2,
+            "dash": "4 2"
+        },
+        {
+            "id": "minor",
+            "description": "Minor Connections",
+            "details": "There is at least one minor connection between the books which may enhance your understanding of the plot and Cosmere in a small way.",
+            "color": "#a09713",
+            "highlightColor": "#a09713",
+            "width": 1,
+            "dash": "3",
+            "activeByDefault": false
+        },
+        {
+            "id": "egg",
+            "description": "Easter Eggs",
+            "details": "There is at least one subtle reference between the books which may hint at something bigger going on. Easter eggs may be very difficult to spot unaided.",
+            "color": "#4d4d4d",
+            "highlightColor": "#4d4d4d",
+            "width": 1,
+            "dash": "2",
+            "activeByDefault": false
+        }
+    ],
+    "layers": [
+        {
+            "id": "pub-status",
+            "name": "Publication Status",
+            "categories": [
+                {
+                    "id": "published",
+                    "description": "Published",
+                    "details": "Published, canonical works.",
+                    "color": "#FFFFFF"
+                },
+                {
+                    "id": "forthcoming",
+                    "description": "Forthcoming",
+                    "details": "Forthcoming works with a planned release month or which are being actively worked on. Expected publication dates may be in parenthesis. Titles may be tentative.",
+                    "color": "#888888"
+                },
+                {
+                    "id": "unpublished",
+                    "description": "Future Plans",
+                    "details": "Includes all planned future cosmere stories. Likelihood of publication varies. Expected publication dates may be in parenthesis. Titles are tentative.",
+                    "color": "#505050"
+                },
+                {
+                    "id": "noncanon",
+                    "description": "Other",
+                    "details": "Uncanonical works which are publicly available, both excerpts and complete.",
+                    "color": "#735a45"
+                }
+            ]
+        },
+        {
+            "id": "series",
+            "name": "Series",
+            "startActive": true,
+            "categories": [
+                {
+                    "id": "elantris",
+                    "description": "Elantris",
+                    "details": "Elantris and its sequels.",
+                    "color": "#58b06e"
+                },
+                {
+                    "id": "mistborn",
+                    "description": "Mistborn",
+                    "details": "Mistborn (all eras)",
+                    "color": "#9973bf"
+                },
+                {
+                    "id": "warbreaker",
+                    "description": "Warbreaker",
+                    "details": "Warbreaker and its sequel.",
+                    "color": "#de4343"
+                },
+                {
+                    "id": "stormlight",
+                    "description": "Stormlight Archive",
+                    "details": "The Stormlight Archive",
+                    "color": "#2aa1d4"
+                },
+                {
+                    "id": "white-sand",
+                    "description": "White Sand",
+                    "details": "White Sand and its sequels.",
+                    "color": "#d4c955"
+                },
+                {
+                    "id": "dragonsteel",
+                    "description": "Dragonsteel",
+                    "details": "Dragonsteel",
+                    "color": "#d98a41"
+                },
+                {
+                    "id": "aether",
+                    "description": "Aether",
+                    "details": "Aether series",
+                    "color": "#e3a1e3"
+                },
+                {
+                    "id": "no-series",
+                    "description": "Non-series Stories",
+                    "details": "Stories not part of a series.",
+                    "color": "#A0A0A0"
+                }
+            ]
+        },
+        {
+            "id": "reading-order",
+            "name": "Reading Order",
+            "categories": [
+                {
+                    "id": "phase1",
+                    "description": "Phase 1 - Essential",
+                    "details": "Essential Phase 1 stories should be read before moving to Phase 2.",
+                    "color": "#00b02b"
+                },
+                {
+                    "id": "phase1b",
+                    "description": "Phase 1 - Secondary",
+                    "details": "Secondary Phase 1 stories may be read during Phase 1 or anytime after.",
+                    "color": "#7bb088"
+                },
+                {
+                    "id": "phase2",
+                    "description": "Phase 2 - Essential",
+                    "details": "Essential Phase 2 stories should be read after all essential Phase 1 works and before moving to Phase 3.",
+                    "color": "#0094d4"
+                },
+                {
+                    "id": "phase2b",
+                    "description": "Phase 2 - Secondary",
+                    "details": "Secondary Phase 2 stories may be read during Phase 2 or anytime after.",
+                    "color": "#8abdd4"
+                },
+                {
+                    "id": "plan",
+                    "description": "Unpublished - Future Plans",
+                    "details": "Includes all planned future cosmere stories. Likelihood of publication varies. Known publication dates may be in parenthesis. Titles are tentative.",
+                    "color": "#505050"
+                },
+                {
+                    "id": "apocryphal",
+                    "description": "Unpublished - Apocryphal",
+                    "details": "Includes unpublished, apocryphal stories. Some elements may be part of the official continuity. Some may be published in the future while others will not.",
+                    "color": "#735a45"
+                }
+            ]
+        },
+        {
+            "id": "formats",
+            "name": "Formats",
+            "startCollapsed": true,
+            "categories": [
+                {
+                    "id": "novel",
+                    "description": "Novels",
+                    "details": "Full novels.",
+                    "color": "#fc4422"
+                },
+                {
+                    "id": "graphic",
+                    "description": "Graphic Novels",
+                    "details": "Graphic novels.",
+                    "style": "italic",
+                    "color": "#fe8062"
+                },
+                {
+                    "id": "novella",
+                    "description": "Novellas",
+                    "details": "Novellas.",
+                    "style": "italic",
+                    "color": "#ffc8ba"
+                },
+                {
+                    "id": "short",
+                    "description": "Short Stories",
+                    "details": "Short stories.",
+                    "style": "italic",
+                    "color": "#fbe8e6"
+                }
+            ]
+        }
+    ],
+    "sorting": [
+        {
+            "id": "order",
+            "description": "Reading order"
+        },
+        {
+            "id": "publication",
+            "description": "Publication date"
+        },
+        {
+            "id": "chronology",
+            "description": "Cosmere timeline"
+        }
+    ],
+    "appearances": [
+        {
+            "id": "hoid",
+            "description": "Hoid",
+            "initial": "H",
+            "color": "#A0A0A0",
+            "details": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a>'s appearances (solid) and mentions (outline)."
+        },
+        {
+            "id": "khriss",
+            "description": "Khriss",
+            "initial": "K",
+            "color": "#A0A0A0",
+            "details": "<a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a>'s appearances (solid) and mentions (outline), not counting the <a target='_blank' href='https://coppermind.net/wiki/Ars_Arcanum'>Ars Arcanum</a>."
+        },
+        {
+            "id": "nazh",
+            "description": "Nazh",
+            "initial": "N",
+            "color": "#A0A0A0",
+            "details": "<a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a>'s appearances (solid) and mentions (outline)."
+        },
+        {
+            "id": "ars",
+            "description": "Ars Arcanum",
+            "initial": "A",
+            "color": "#A0A0A0",
+            "details": "Stories that include an <a target='_blank' href='https://coppermind.net/wiki/Ars_Arcanum'>Ars Arcanum</a>."
+        }
+    ],
+    "books": [
+        {
+            "label": "Sel",
+            "color": "#58b06e",
+            "children": [
+                {
+                    "label": "Elantris",
+                    "children": [
+                        {
+                            "id": "elantris",
+                            "title": "Elantris",
+                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Elantris'>Elantris</a>",
+                            "series": "Elantris",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Sel'>Sel</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Selish_system'>Selish system</a>",
+                            "publication": "April 2005",
+                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/298/#e9926'>Occurs long before Mistborn Era 1, but not thousands of years before.</a>",
+                            "sorting": {
+				"order": 1.3,
+                                "publication": 2005.04,
+                                "chronology": 3.1
+                            },
+                            "appearances": [
+                                {
+                                    "id": "hoid",
+                                    "type": "appearance",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a>'s first appearance. <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is the beggar that works with <a target='_blank' href='https://coppermind.net/wiki/Sarene'>Sarene</a> in <a target='_blank' href='https://coppermind.net/wiki/Summary:Elantris#Chapter_58'>Chapter 58</a>. The tenth anniversary edition includes <a target='_blank' href='https://coppermind.net/wiki/Summary:Elantris#Postscript'>a postscript</a> with <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> in it."
+                                },
+                                {
+                                    "id": "nazh",
+                                    "type": "mention",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a>'s annotations can be found on the map of <a target='_blank' href='https://coppermind.net/wiki/Sycla'>Sycla</a>."
+                                },
+                                {
+                                    "id": "ars",
+                                    "type": "appearance"
+                                }
+                            ],
+                            "categories": [ "elantris", "phase1", "published", "novel" ],
+                            "connections": [
+                                {
+                                    "target": "tes",
+                                    "type": "minor",
+                                    "description": "The map in <a target='_blank' href='https://coppermind.net/wiki/Elantris'>Elantris</a> refers to '<a target='_blank' href='https://coppermind.net/wiki/Rose_Empire'>Rose Barbarians</a>'. There are mentions of <a target='_blank' href='https://coppermind.net/wiki/Svorden'>Svorden</a>, <a target='_blank' href='https://coppermind.net/wiki/Teod'>Teod</a>, and <a target='_blank' href='https://coppermind.net/wiki/Sycla'>Sycla</a>. When escaping the palace, <a target='_blank' href='https://coppermind.net/wiki/Shai'>Shai</a> runs into a <a target='_blank' href='https://coppermind.net/wiki/Shu-Dereth'>Derethi priest</a> (wearing red armor). When she steals the painting she inscribes an <a target='_blank' href='https://coppermind.net/wiki/Aon'>Aon Reo</a> in its place."
+                                },
+                                {
+                                    "target": "msh",
+                                    "type": "significant",
+                                    "description": "The <a target='_blank' href='https://coppermind.net/wiki/Ire'>Ire</a> are <a target='_blank' href='https://coppermind.net/wiki/Elantrian'>Elantrians</a>. Their symbol is <a target='_blank' href='https://coppermind.net/wiki/Aon'>Aon Ire</a>."
+                                },
+                                {
+                                    "target": "sa1",
+                                    "type": "egg",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Galladon'>Galladon</a> appears in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Way_of_Kings#Interlude_I-1:_Ishikk'>Interlude I-1</a> as 'Grump'. Note his use of 'sule' (friend) and 'kolo' (understand) as well as the <a target='_blank' href='https://coppermind.net/wiki/Duladel'>Dula</a> word 'kayana' (crazy). Also, <a target='_blank' href='https://coppermind.net/wiki/Aona'>Aona</a> and <a target='_blank' href='https://coppermind.net/wiki/Skai'>Skai</a> are mentioned in the <a target='_blank' href='https://coppermind.net/wiki/https://coppermind.net/wiki/The_Way_of_Kings/Epigraphs#The_Letter'>Chapter 22 epigraph</a>."
+                                },
+                                {
+                                    "target": "sa3",
+                                    "type": "minor",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Riino'>Riino</a>, the lighthouse owner in <a target='_blank' href='https://coppermind.net/wiki/Summary:Oathbringer#Chapter_97:_Riino'>Chapter 97</a>, is the <a target='_blank' href='https://coppermind.net/wiki/Hoed'>Hoed</a> <a target='_blank' href='https://coppermind.net/wiki/Raoden'>Raoden</a> and <a target='_blank' href='https://coppermind.net/wiki/Galladon'>Galladon</a> lowered into the <a target='_blank' href='https://coppermind.net/wiki/Devotion's_Perpendicularity'>mountain lake</a>."
+                                },
+                                {
+                                    "target": "au",
+                                    "type": "minor",
+                                    "description": "The nature of <a target='_blank' href='https://coppermind.net/wiki/Sel'>Sel</a>'s magic is discussed in the <a target='_blank' href='https://coppermind.net/wiki/Selish_system'>Selish system</a> essay."
+                                },
+                                {
+                                    "target": "sa4",
+                                    "type": "minor",
+                                    "description": "The communication box used by <a target='_blank' href='https://coppermind.net/wiki/Shallan'>Shallan</a> to communicate with <a target='_blank' href='https://coppermind.net/wiki/Mraize'>Mraize</a> and <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> contains a <a target='_blank' href='https://coppermind.net/wiki/Seon'>Seon</a>."
+                                },
 				{
-					"id": "published",
-					"description": "Published",
-					"details": "Published, canonical works.",
-					"color": "#FFFFFF"
-				},
-				{
-					"id": "forthcoming",
-					"description": "Forthcoming",
-					"details": "Forthcoming works with a planned release month or which are being actively worked on. Expected publication dates may be in parenthesis. Titles may be tentative.",
-					"color": "#888888"
-				},
-				{
-					"id": "unpublished",
-					"description": "Future Plans",
-					"details": "Includes all planned future cosmere stories. Likelihood of publication varies. Expected publication dates may be in parenthesis. Titles are tentative.",
-					"color": "#505050"
-				},
-				{
-					"id": "noncanon",
-					"description": "Other",
-					"details": "Uncanonical works which are publicly available, both excerpts and complete.",
-					"color": "#735a45"
+				    "target": "mb7",
+				    "type": "major",
+				    "description": "WIP"
 				}
-			]
-		},
-		{
-			"id": "series",
-			"name": "Series",
-			"startActive": true,
-			"categories": [
+                            ]
+                        },
+                        {
+                            "id": "thoe",
+                            "title": "The Hope of Elantris",
+                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Hope_of_Elantris'>The Hope of Elantris</a>",
+                            "series": "Elantris",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Sel'>Sel</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Selish_system'>Selish system</a>",
+                            "au": "Included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
+                            "link": "<a target='_blank' href='https://brandonsanderson.com/elantris-the-hope-of-elantris'>Full text on Brandon's website.</a>",
+                            "padding": 12,
+                            "publication": "January 2006",
+                            "chronology": "Shortly after the events of Elantris, and concerning events during the end of that book.",
+                            "sorting": {
+				"order": 1.31,
+                                "publication": 2006.01,
+                                "chronology": 3.11
+                            },
+                            "categories": [ "elantris", "phase1b", "published", "short" ]
+                        },
+                        {
+                            "id": "elantris2",
+                            "title": "Elantris 2",
+                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Elantris_sequel'>Elantris 2</a>",
+                            "series": "Elantris",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Sel'>Sel</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Selish_system'>Selish system</a>",
+                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/395/#e13072'>A short time jump is planned between Elantris books, with the original main characters still being alive.</a>",
+                            "sorting": {
+                                "chronology": 3.2
+                            },
+                            "categories": [ "elantris", "plan", "unpublished", "novel" ]
+                        },
+                        {
+                            "id": "elantris3",
+                            "title": "Elantris 3",
+                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Elantris_finale'>Elantris 3</a>",
+                            "series": "Elantris",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Sel'>Sel</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Selish_system'>Selish system</a>",
+                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/395/#e13072'>A short time jump is planned between Elantris books, with the original main characters still being alive.</a>",
+                            "sorting": {
+                                "chronology": 3.3
+                            },
+                            "categories": [ "elantris", "plan", "unpublished", "novel" ]
+                        }
+                    ]
+                },
+                {
+                    "children": [
+                        {
+                            "id": "tes",
+                            "title": "The Emperor's Soul",
+                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Emperor&#39s_Soul'>The Emperor's Soul</a>",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Sel'>Sel</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Selish_system'>Selish system</a>",
+                            "au": "Included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
+                            "publication": "November 2012",
+                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/109/#e1410'>After Elantris, but within the characters' lifetimes.</a> Note this could place it prior to Elantris 2 and/or 3.",
+                            "sorting": {
+				"order": 1.4,
+                                "publication": 2012.11,
+                                "chronology": 3.5
+                            },
+                            "appearances": [
+                                {
+                                    "id": "hoid",
+                                    "type": "mention",
+                                    "description": "The 'Imperial Fool' is <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a>."
+                                }
+                            ],
+                            "categories": [ "no-series", "phase1b", "published", "novella" ],
+                            "connections": [
+                                {
+                                    "target": "imperial-fool",
+                                    "type": "major",
+                                    "description": "A deleted prologue that contains some canonical elements."
+                                },
+                                {
+                                    "target": "au",
+                                    "type": "minor",
+                                    "description": "The nature of <a target='_blank' href='https://coppermind.net/wiki/Sel'>Sel</a>'s magic is discussed in the <a target='_blank' href='https://coppermind.net/wiki/Selish_system'>Selish system</a> essay."
+                                },
+                                {
+                                    "target": "sa4",
+                                    "type": "egg",
+                                    "description": "The <a target='_blank' href='https://coppermind.net/wiki/Fused'>Fused</a> refer to <a target='_blank' href='https://coppermind.net/wiki/aluminum'>aluminum</a> as Ralkalest."
+                                },
 				{
-					"id": "elantris",
-					"description": "Elantris",
-					"details": "Elantris and its sequels.",
-					"color": "#58b06e"
-				},
-				{
-					"id": "mistborn",
-					"description": "Mistborn",
-					"details": "Mistborn (all eras)",
-					"color": "#9973bf"
-				},
-				{
-					"id": "warbreaker",
-					"description": "Warbreaker",
-					"details": "Warbreaker and its sequel.",
-					"color": "#de4343"
-				},
-				{
-					"id": "stormlight",
-					"description": "Stormlight Archive",
-					"details": "The Stormlight Archive",
-					"color": "#2aa1d4"
-				},
-				{
-					"id": "white-sand",
-					"description": "White Sand",
-					"details": "White Sand and its sequels.",
-					"color": "#d4c955"
-				},
-				{
-					"id": "dragonsteel",
-					"description": "Dragonsteel",
-					"details": "Dragonsteel",
-					"color": "#d98a41"
-				},
-				{
-					"id": "aether",
-					"description": "Aether",
-					"details": "Aether series",
-					"color": "#e3a1e3"
-				},
-				{
-					"id": "no-series",
-					"description": "Non-series Stories",
-					"details": "Stories not part of a series.",
-					"color": "#A0A0A0"
+				    "target": "mb7",
+				    "type": "major",
+				    "description": "WIP"
 				}
-			]
-		},
-		{
-			"id": "reading-order",
-			"name": "Reading Order",
-			"categories": [
-				{
-					"id": "phase1",
-					"description": "Phase 1 - Essential",
-					"details": "Essential Phase 1 stories should be read before moving to Phase 2.",
-					"color": "#00b02b"
-				},
-				{
-					"id": "phase1b",
-					"description": "Phase 1 - Secondary",
-					"details": "Secondary Phase 1 stories may be read during Phase 1 or anytime after.",
-					"color": "#7bb088"
-				},
-				{
-					"id": "phase2",
-					"description": "Phase 2 - Essential",
-					"details": "Essential Phase 2 stories should be read after all essential Phase 1 works and before moving to Phase 3.",
-					"color": "#0094d4"
-				},
-				{
-					"id": "phase2b",
-					"description": "Phase 2 - Secondary",
-					"details": "Secondary Phase 2 stories may be read during Phase 2 or anytime after.",
-					"color": "#8abdd4"
-				},
-				{
-					"id": "plan",
-					"description": "Unpublished - Future Plans",
-					"details": "Includes all planned future cosmere stories. Likelihood of publication varies. Known publication dates may be in parenthesis. Titles are tentative.",
-					"color": "#505050"
-				},
-				{
-					"id": "apocryphal",
-					"description": "Unpublished - Apocryphal",
-					"details": "Includes unpublished, apocryphal stories. Some elements may be part of the official continuity. Some may be published in the future while others will not.",
-					"color": "#735a45"
-				}
-			]
-		},
-		{
-			"id": "formats",
-			"name": "Formats",
-			"startCollapsed": true,
-			"categories": [
-				{
-					"id": "novel",
-					"description": "Novels",
-					"details": "Full novels.",
-					"color": "#fc4422"
-				},
-				{
-					"id": "graphic",
-					"description": "Graphic Novels",
-					"details": "Graphic novels.",
-					"style": "italic",
-					"color": "#fe8062"
-				},
-				{
-					"id": "novella",
-					"description": "Novellas",
-					"details": "Novellas.",
-					"style": "italic",
-					"color": "#ffc8ba"
-				},
-				{
-					"id": "short",
-					"description": "Short Stories",
-					"details": "Short stories.",
-					"style": "italic",
-					"color": "#fbe8e6"
-				}
-			]
-		}
-	],
-	"sorting": [
-		{
-			"id": "order",
-			"description": "Reading order"
-		},
-		{
-			"id": "publication",
-			"description": "Publication date"
-		},
-		{
-			"id": "chronology",
-			"description": "Cosmere timeline"
-		}
-	],
-	"appearances": [
-		{
-			"id": "hoid",
-			"description": "Hoid",
-			"initial": "H",
-			"color": "#A0A0A0",
-			"details": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a>'s appearances (solid) and mentions (outline)."
-		},
-		{
-			"id": "khriss",
-			"description": "Khriss",
-			"initial": "K",
-			"color": "#A0A0A0",
-			"details": "<a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a>'s appearances (solid) and mentions (outline), not counting the <a target='_blank' href='https://coppermind.net/wiki/Ars_Arcanum'>Ars Arcanum</a>."
-		},
-		{
-			"id": "nazh",
-			"description": "Nazh",
-			"initial": "N",
-			"color": "#A0A0A0",
-			"details": "<a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a>'s appearances (solid) and mentions (outline)."
-		},
-		{
-			"id": "ars",
-			"description": "Ars Arcanum",
-			"initial": "A",
-			"color": "#A0A0A0",
-			"details": "Stories that include an <a target='_blank' href='https://coppermind.net/wiki/Ars_Arcanum'>Ars Arcanum</a>."
-		}
-	],
-	"books": [
-		{
-			"label": "Sel",
-			"color": "#58b06e",
-			"children": [
-				{
-					"label": "Elantris",
-					"children": [
-						{
-							"id": "elantris",
-							"title": "Elantris",
-							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Elantris'>Elantris</a>",
-							"series": "Elantris",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Sel'>Sel</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Selish_system'>Selish system</a>",
-							"publication": "April 2005",
-							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/298/#e9926'>Occurs long before Mistborn Era 1, but not thousands of years before.</a>",
-							"sorting": {
-								"order": 1.3,
-								"publication": 2005.04,
-								"chronology": 3.1
-							},
-							"appearances": [
-								{
-									"id": "hoid",
-									"type": "appearance",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a>'s first appearance. <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is the beggar that works with <a target='_blank' href='https://coppermind.net/wiki/Sarene'>Sarene</a> in <a target='_blank' href='https://coppermind.net/wiki/Summary:Elantris#Chapter_58'>Chapter 58</a>. The tenth anniversary edition includes <a target='_blank' href='https://coppermind.net/wiki/Summary:Elantris#Postscript'>a postscript</a> with <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> in it."
-								},
-								{
-									"id": "nazh",
-									"type": "mention",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a>'s annotations can be found on the map of <a target='_blank' href='https://coppermind.net/wiki/Sycla'>Sycla</a>."
-								},
-								{
-									"id": "ars",
-									"type": "appearance"
-								}
-							],
-							"categories": [
-								"elantris",
-								"phase1",
-								"published",
-								"novel"
-							],
-							"connections": [
-								{
-									"target": "tes",
-									"type": "minor",
-									"description": "The map in <a target='_blank' href='https://coppermind.net/wiki/Elantris'>Elantris</a> refers to '<a target='_blank' href='https://coppermind.net/wiki/Rose_Empire'>Rose Barbarians</a>'. There are mentions of <a target='_blank' href='https://coppermind.net/wiki/Svorden'>Svorden</a>, <a target='_blank' href='https://coppermind.net/wiki/Teod'>Teod</a>, and <a target='_blank' href='https://coppermind.net/wiki/Sycla'>Sycla</a>. When escaping the palace, <a target='_blank' href='https://coppermind.net/wiki/Shai'>Shai</a> runs into a <a target='_blank' href='https://coppermind.net/wiki/Shu-Dereth'>Derethi priest</a> (wearing red armor). When she steals the painting she inscribes an <a target='_blank' href='https://coppermind.net/wiki/Aon'>Aon Reo</a> in its place."
-								},
-								{
-									"target": "msh",
-									"type": "significant",
-									"description": "The <a target='_blank' href='https://coppermind.net/wiki/Ire'>Ire</a> are <a target='_blank' href='https://coppermind.net/wiki/Elantrian'>Elantrians</a>. Their symbol is <a target='_blank' href='https://coppermind.net/wiki/Aon'>Aon Ire</a>."
-								},
-								{
-									"target": "sa1",
-									"type": "egg",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Galladon'>Galladon</a> appears in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Way_of_Kings#Interlude_I-1:_Ishikk'>Interlude I-1</a> as 'Grump'. Note his use of 'sule' (friend) and 'kolo' (understand) as well as the <a target='_blank' href='https://coppermind.net/wiki/Duladel'>Dula</a> word 'kayana' (crazy). Also, <a target='_blank' href='https://coppermind.net/wiki/Aona'>Aona</a> and <a target='_blank' href='https://coppermind.net/wiki/Skai'>Skai</a> are mentioned in the <a target='_blank' href='https://coppermind.net/wiki/https://coppermind.net/wiki/The_Way_of_Kings/Epigraphs#The_Letter'>Chapter 22 epigraph</a>."
-								},
-								{
-									"target": "sa3",
-									"type": "minor",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Riino'>Riino</a>, the lighthouse owner in <a target='_blank' href='https://coppermind.net/wiki/Summary:Oathbringer#Chapter_97:_Riino'>Chapter 97</a>, is the <a target='_blank' href='https://coppermind.net/wiki/Hoed'>Hoed</a> <a target='_blank' href='https://coppermind.net/wiki/Raoden'>Raoden</a> and <a target='_blank' href='https://coppermind.net/wiki/Galladon'>Galladon</a> lowered into the <a target='_blank' href='https://coppermind.net/wiki/Devotion's_Perpendicularity'>mountain lake</a>."
-								},
-								{
-									"target": "au",
-									"type": "minor",
-									"description": "The nature of <a target='_blank' href='https://coppermind.net/wiki/Sel'>Sel</a>'s magic is discussed in the <a target='_blank' href='https://coppermind.net/wiki/Selish_system'>Selish system</a> essay."
-								},
-								{
-									"target": "sa4",
-									"type": "minor",
-									"description": "The communication box used by <a target='_blank' href='https://coppermind.net/wiki/Shallan'>Shallan</a> to communicate with <a target='_blank' href='https://coppermind.net/wiki/Mraize'>Mraize</a> and <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> contains a <a target='_blank' href='https://coppermind.net/wiki/Seon'>Seon</a>."
-								},
-								{
-									"target": "mb7",
-									"type": "major",
-									"description": "(WIP) Codenames is Kaise. Shay-I (Moonlight) uses AonDor in chapter 54. Codenames communicate with Kelsier using Seon Dao"
-								}
-							]
-						},
-						{
-							"id": "thoe",
-							"title": "The Hope of Elantris",
-							"title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Hope_of_Elantris'>The Hope of Elantris</a>",
-							"series": "Elantris",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Sel'>Sel</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Selish_system'>Selish system</a>",
-							"au": "Included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
-							"link": "<a target='_blank' href='https://brandonsanderson.com/elantris-the-hope-of-elantris'>Full text on Brandon's website.</a>",
-							"padding": 12,
-							"publication": "January 2006",
-							"chronology": "Shortly after the events of Elantris, and concerning events during the end of that book.",
-							"sorting": {
-								"order": 1.31,
-								"publication": 2006.01,
-								"chronology": 3.11
-							},
-							"categories": [
-								"elantris",
-								"phase1b",
-								"published",
-								"short"
-							]
-						},
-						{
-							"id": "elantris2",
-							"title": "Elantris 2",
-							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Elantris_sequel'>Elantris 2</a>",
-							"series": "Elantris",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Sel'>Sel</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Selish_system'>Selish system</a>",
-							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/395/#e13072'>A short time jump is planned between Elantris books, with the original main characters still being alive.</a>",
-							"sorting": {
-								"chronology": 3.2
-							},
-							"categories": [
-								"elantris",
-								"plan",
-								"unpublished",
-								"novel"
-							]
-						},
-						{
-							"id": "elantris3",
-							"title": "Elantris 3",
-							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Elantris_finale'>Elantris 3</a>",
-							"series": "Elantris",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Sel'>Sel</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Selish_system'>Selish system</a>",
-							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/395/#e13072'>A short time jump is planned between Elantris books, with the original main characters still being alive.</a>",
-							"sorting": {
-								"chronology": 3.3
-							},
-							"categories": [
-								"elantris",
-								"plan",
-								"unpublished",
-								"novel"
-							]
-						}
-					]
-				},
-				{
-					"children": [
-						{
-							"id": "tes",
-							"title": "The Emperor's Soul",
-							"title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Emperor&#39s_Soul'>The Emperor's Soul</a>",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Sel'>Sel</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Selish_system'>Selish system</a>",
-							"au": "Included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
-							"publication": "November 2012",
-							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/109/#e1410'>After Elantris, but within the characters' lifetimes.</a> Note this could place it prior to Elantris 2 and/or 3.",
-							"sorting": {
-								"order": 1.4,
-								"publication": 2012.11,
-								"chronology": 3.5
-							},
-							"appearances": [
-								{
-									"id": "hoid",
-									"type": "mention",
-									"description": "The 'Imperial Fool' is <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a>."
-								}
-							],
-							"categories": [
-								"no-series",
-								"phase1b",
-								"published",
-								"novella"
-							],
-							"connections": [
-								{
-									"target": "imperial-fool",
-									"type": "major",
-									"description": "A deleted prologue that contains some canonical elements."
-								},
-								{
-									"target": "au",
-									"type": "minor",
-									"description": "The nature of <a target='_blank' href='https://coppermind.net/wiki/Sel'>Sel</a>'s magic is discussed in the <a target='_blank' href='https://coppermind.net/wiki/Selish_system'>Selish system</a> essay."
-								},
-								{
-									"target": "sa4",
-									"type": "egg",
-									"description": "The <a target='_blank' href='https://coppermind.net/wiki/Fused'>Fused</a> refer to <a target='_blank' href='https://coppermind.net/wiki/aluminum'>aluminum</a> as Ralkalest."
-								},
-								{
-									"target": "mb7",
-									"type": "major",
-									"description": "(WIP) Moonlight is Shai; she uses Forgery on several occasions and takes on the name Shay-I after using her essence marks"
-								}
-							]
-						},
-						{
-							"id": "tes2",
-							"title": "The Emperor's Soul sequel",
-							"title2": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>Untitled Emperor's Soul sequel</a>",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Sel'>Sel</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Selish_system'>Selish system</a>",
-							"categories": [
-								"no-series",
-								"plan",
-								"unpublished",
-								"novella"
-							]
-						}
-					]
-				}
-			]
-		},
-		{
-			"label": "Scadrial",
-			"color": "#9973bf",
-			"children": [
-				{
-					"label": "Mistborn<br>Era 1",
-					"children": [
-						{
-							"id": "mb1",
-							"title": "Mistborn: The Final Empire",
-							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn:_The_Final_Empire'>Mistborn: The Final Empire</a>",
-							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 1)",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-							"publication": "July 2006",
-							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/176/#e8494'>Mistborn Era 1 occurs prior to The Stormlight Archive.",
-							"sorting": {
-								"order": 1.11,
-								"publication": 2006.07,
-								"chronology": 4.1
-							},
-							"appearances": [
-								{
-									"id": "hoid",
-									"type": "appearance",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Kelsier'>Kelsier</a> meets with <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> in <a target='_blank' href='https://coppermind.net/wiki/Summary:Mistborn:_The_Final_Empire#Chapter_19'>Chapter 19</a>."
-								},
-								{
-									"id": "nazh",
-									"type": "mention",
-									"description": "Annotations by <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> can be found on the map of <a target='_blank' href='https://coppermind.net/wiki/Luthadel'>Luthadel</a>."
-								},
-								{
-									"id": "ars",
-									"type": "appearance"
-								}
-							],
-							"categories": [
-								"mistborn",
-								"phase1",
-								"published",
-								"novel"
-							]
-						},
-						{
-							"id": "11m",
-							"title": "The Eleventh Metal",
-							"title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Eleventh_Metal'>The Eleventh Metal</a>",
-							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 1)",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-							"au": "Included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
-							"padding": 12,
-							"publication": "December 2011",
-							"chronology": "Concerns Kelsier's training, years before Mistborn: The Final Empire.",
-							"sorting": {
-								"order": 1.14,
-								"publication": 2011.12,
-								"chronology": 4.09
-							},
-							"categories": [
-								"mistborn",
-								"short",
-								"phase1b",
-								"published"
-							]
-						},
-						{
-							"id": "mb2",
-							"title": "The Well of Ascension",
-							"title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Well_of_Ascension'>The Well of Ascension</a>",
-							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 1)",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-							"publication": "August 2007",
-							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/176/#e8494'>Mistborn Era 1 occurs prior to The Stormlight Archive.",
-							"sorting": {
-								"order": 1.12,
-								"publication": 2007.08,
-								"chronology": 4.2
-							},
-							"appearances": [
-								{
-									"id": "hoid",
-									"type": "appearance",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is among the <a target='_blank' href='https://coppermind.net/wiki/Terris'>Terris</a> refugees in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Well_of_Ascension#Chapter_56'>Chapter 56</a>, <a target='_blank' href='https://wob.coppermind.net/events/130/#e1552'>according to Brandon</a>."
-								},
-								{
-									"id": "nazh",
-									"type": "mention",
-									"description": "Annotations by <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> can be found on the map of <a target='_blank' href='https://coppermind.net/wiki/Luthadel'>Luthadel</a>."
-								},
-								{
-									"id": "ars",
-									"type": "appearance"
-								}
-							],
-							"categories": [
-								"mistborn",
-								"phase1",
-								"published",
-								"novel"
-							],
-							"connections": [
-								{
-									"target": "wb",
-									"type": "egg",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Lemex%27s_nurse'>Lemex's nurse</a> is a <a target='_blank' href='https://coppermind.net/wiki/Terris'>Terriswoman</a>."
-								}
-							]
-						},
-						{
-							"id": "mb3",
-							"title": "The Hero of Ages",
-							"title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Hero_of_Ages'>The Hero of Ages</a>",
-							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 1)",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-							"publication": "October 2008",
-							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/176/#e8494'>Mistborn Era 1 occurs prior to The Stormlight Archive.",
-							"sorting": {
-								"order": 1.13,
-								"publication": 2008.1,
-								"chronology": 4.3
-							},
-							"appearances": [
-								{
-									"id": "hoid",
-									"type": "mention",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is the informant that <a target='_blank' href='https://coppermind.net/wiki/Vin'>Vin</a> was supposed to meet with in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Hero_of_Ages#Chapter_27'>Chapter 27</a>."
-								},
-								{
-									"id": "nazh",
-									"type": "mention",
-									"description": "Annotations by <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> can be found on the map of <a target='_blank' href='https://coppermind.net/wiki/Luthadel'>Luthadel</a>."
-								},
-								{
-									"id": "ars",
-									"type": "appearance"
-								}
-							],
-							"categories": [
-								"mistborn",
-								"phase1",
-								"published",
-								"novel"
-							],
-							"connections": [
-								{
-									"target": "sa1",
-									"type": "egg",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Demoux'>Demoux</a> appears in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Way_of_Kings#Interlude_I-1:_Ishikk'>Interlude I-1</a> as 'Thinker'; <a target='_blank' href='https://coppermind.net/wiki/Ishikk'>Ishikk</a> mishears his name as 'Temoo'. <a target='_blank' href='https://coppermind.net/wiki/Ruin'>Ruin</a>'s <a target='_blank' href='https://coppermind.net/wiki/vessel'>vessel</a>, <a target='_blank' href='https://coppermind.net/wiki/Ati'>Ati</a>, is mentioned in the <a target='_blank' href='https://coppermind.net/wiki/https://coppermind.net/wiki/The_Way_of_Kings/Epigraphs#The_Letter'>Chapter 18 epigraph</a>. <a target='_blank' href='https://coppermind.net/wiki/Felt'>Felt</a> worked for the <a target='_blank' href='https://coppermind.net/wiki/House_Venture'>House Venture</a> on <a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>."
-								},
-								{
-									"target": "sa2",
-									"type": "egg",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Wit</a> appears to use <a target='_blank' href='https://coppermind.net/wiki/Allomancy'>emotional Allomancy</a> in <a target='_blank' href='https://coppermind.net/wiki/Summary:Words_of_Radiance#Chapter_45:_Middlefest'>Chapter 45</a>."
-								},
-								{
-									"target": "sa3",
-									"type": "significant",
-									"description": "The <a target='_blank' href='https://coppermind.net/wiki/Oathbringer/Epigraphs#Letters'>Part 2 epigraphs</a> include <a target='_blank' href='https://coppermind.net/wiki/Letters#Third_Oathbringer_Letter'>a letter</a> from <a target='_blank' href='https://coppermind.net/wiki/Sazed'>Sazed</a> to <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a>. <a target='_blank' href='https://coppermind.net/wiki/Felt'>Felt</a> reveals he is from another world."
-								},
-								{
-									"target": "au",
-									"type": "major",
-									"description": "The <a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a> essay discusses the events that occurred in <a target='_blank' href='https://coppermind.net/wiki/The_Hero_of_Ages'>The Hero of Ages</a>."
-								},
-								{
-									"target": "sa4",
-									"type": "significant",
-									"description": "The <a target='_blank' href='https://coppermind.net/wiki/Rhythm_of_War/Epigraphs'>Part 2 Epigraphs</a> are a letter from <a target='_blank' href='https://coppermind.net/wiki/Harmony'>Harmony</a>. <a target='_blank' href='https://coppermind.net/wiki/Fabrial'>Fabrial</a> metals have similar effects as in the <a target='_blank' href='https://coppermind.net/wiki/Metallic_Arts'>Metalic Arts</a>. <a target='_blank' href='https://coppermind.net/wiki/Gereh'>Gereh</a> and <a target='_blank' href='https://coppermind.net/wiki/Axindweth'>Axindweth</a> are <a target='_blank' href='https://coppermind.net/wiki/Feruchemy'>Feruchemists</a>. <a target='_blank' href='https://coppermind.net/wiki/Raysium'>Raysium</a> is associated with <a target='_blank' href='https://coppermind.net/wiki/Odium'>Odium</a> as <a target='_blank' href='https://coppermind.net/wiki/atium'>atium</a> is associated with <a target='_blank' href='https://coppermind.net/wiki/Ruin'>Ruin</a>."
-								}
-							]
-						}
-					]
-				},
-				{
-					"label": "Mistborn<br>Era 2",
-					"children": [
-						{
-							"id": "mb4",
-							"title": "The Alloy of Law",
-							"title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Alloy_of_Law'>The Alloy of Law</a>",
-							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 2)",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-							"publication": "November 2011",
-							"chronology": "Mistborn Era 2 occurs <a target='_blank' href='https://wob.coppermind.net/events/260/#e8747'>after Stormlight Archive book 5</a> and <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>before Stormlight Archive book 6</a>.",
-							"sorting": {
-								"order": 2.21,
-								"publication": 2011.11,
-								"chronology": 8.1
-							},
-							"appearances": [
-								{
-									"id": "hoid",
-									"type": "appearance",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is the beggar speaking with <a target='_blank' href='https://coppermind.net/wiki/Joshin_Yomen'>Lord Joshin</a> and <a target='_blank' href='https://coppermind.net/wiki/Mi%27chelle_Yomen'>Lady Mi'chelle</a> in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Alloy_of_Law#Chapter_4'>Chapter 4</a>."
-								},
-								{
-									"id": "nazh",
-									"type": "mention",
-									"description": "Annotations by <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> can be found on the map of <a target='_blank' href='https://coppermind.net/wiki/Elendel'>Elendel</a>."
-								},
-								{
-									"id": "ars",
-									"type": "appearance"
-								}
-							],
-							"categories": [
-								"mistborn",
-								"phase2",
-								"published",
-								"novel"
-							]
-						},
-						{
-							"id": "jak",
-							"title": "Allomancer Jak",
-							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Allomancer_Jak_and_the_Pits_of_Eltania'>Allomancer Jak and the Pits of Eltania</a>",
-							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 2)",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-							"au": "Included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
-							"padding": 12,
-							"publication": "August 2014",
-							"chronology": "Mistborn Era 2 occurs <a target='_blank' href='https://wob.coppermind.net/events/260/#e8747'>after Stormlight Archive book 5</a> and <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>before Stormlight Archive book 6</a>.",
-							"sorting": {
-								"order": 2.22,
-								"publication": 2014.08,
-								"chronology": 8.05
-							},
-							"categories": [
-								"mistborn",
-								"short",
-								"phase2b",
-								"published"
-							]
-						},
-						{
-							"id": "mb5",
-							"title": "Shadows of Self",
-							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Shadows_of_Self'>Shadows of Self</a>",
-							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 2)",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-							"publication": "October 2015",
-							"chronology": "Mistborn Era 2 occurs <a target='_blank' href='https://wob.coppermind.net/events/260/#e8747'>after Stormlight Archive book 5</a> and <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>before Stormlight Archive book 6</a>.",
-							"sorting": {
-								"order": 2.23,
-								"publication": 2015.1,
-								"chronology": 8.2
-							},
-							"appearances": [
-								{
-									"id": "hoid",
-									"type": "appearance",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is <a target='_blank' href='https://coppermind.net/wiki/Waxillium_Laddrian'>Wax</a>'s coachman, named in <a target='_blank' href='https://coppermind.net/wiki/Summary:Shadows_of_Self#Chapter_7'>Chapter 7</a>."
-								},
-								{
-									"id": "ars",
-									"type": "appearance"
-								}
-							],
-							"categories": [
-								"mistborn",
-								"phase2",
-								"published",
-								"novel"
-							]
-						},
-						{
-							"id": "mb6",
-							"title": "The Bands of Mourning",
-							"title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Bands_of_Mourning'>The Bands of Mourning</a>",
-							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 2)",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-							"publication": "January 2016",
-							"chronology": "Mistborn Era 2 occurs <a target='_blank' href='https://wob.coppermind.net/events/260/#e8747'>after Stormlight Archive book 5</a> and <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>before Stormlight Archive book 6</a>.",
-							"sorting": {
-								"order": 2.24,
-								"publication": 2016.01,
-								"chronology": 8.3
-							},
-							"appearances": [
-								{
-									"id": "hoid",
-									"type": "appearance",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is the beggar who gives <a target='_blank' href='https://coppermind.net/wiki/Waxillium_Laddrian'>Wax</a> a special coin in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Bands_of_Mourning#Chapter_11'>Chapter 11</a>."
-								},
-								{
-									"id": "khriss",
-									"type": "appearance",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> is the woman who dances with <a target='_blank' href='https://coppermind.net/wiki/Waxillium_Laddrian'>Wax</a> in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Bands_of_Mourning#Chapter_12'>Chapter 12</a>. <a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> and <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> are also the 'K or N' referred to in the 'Do your metal tools speak to you?' ad in <a target='_blank' href='https://coppermind.net/wiki/The_New_Ascendancy'>The New Ascendancy</a> broadsheet."
-								},
-								{
-									"id": "nazh",
-									"type": "mention",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> is 'the haunted man' in 'The Ghastly Gondola!' story in <a target='_blank' href='https://coppermind.net/wiki/The_New_Ascendancy'>The New Ascendancy</a> broadsheet. (note his 'shadows' curse) <a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> and <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> are also the 'K or N' referred to in the 'Do your metal tools speak to you?' ad in the broadsheet."
-								},
-								{
-									"id": "ars",
-									"type": "appearance"
-								}
-							],
-							"categories": [
-								"mistborn",
-								"phase2",
-								"published",
-								"novel"
-							],
-							"connections": [
-								{
-									"target": "sa2",
-									"type": "egg",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Iyatil'>Iyatil</a> is of <a target='_blank' href='https://coppermind.net/wiki/Southern_Scadrial'>Southern Scadrian</a> descent."
-								},
-								{
-									"target": "msh",
-									"type": "major",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Kelsier'>Kelsier</a>'s survival is revealed in <a target='_blank' href='https://coppermind.net/wiki/The_Bands_of_Mourning'>The Bands of Mourning</a>."
-								},
-								{
-									"target": "sotd2",
-									"type": "minor",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrian</a> spaceships powered by <a target='_blank' href='https://coppermind.net/wiki/Allomancy'>Allomancy</a> are seen."
-								}
-							]
-						},
-						{
-							"id": "mb7",
-							"title": "The Lost Metal (2022)",
-							"title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Lost_Metal'>The Lost Metal</a>",
-							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 2)",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-							"publication": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>Fall 2022</a>",
-							"chronology": "Mistborn Era 2 occurs <a target='_blank' href='https://wob.coppermind.net/events/260/#e8747'>after Stormlight Archive book 5</a> and <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>before Stormlight Archive book 6</a>.",
-							"sorting": {
-								"publication": 2022.11,
-								"chronology": 8.4
-							},
-							"appearances": [
-								{
-									"id": "hoid",
-									"type": "appearance",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is <a target='_blank' href='https://coppermind.net/wiki/Waxillium_Laddrian'>Wax</a>'s coachman, named for the first time in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Lost_Metal#Chapter_7'>Chapter 7</a>."
-								},
-								{
-									"id": "nazh",
-									"type": "mention",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> is 'the haunted man' in 'Nicki Savage and The Compass of Spirits' story in <a target='_blank' href='https://coppermind.net/wiki/The_Two_Seasons'>The Two Seasons</a> broadsheet."
-								},
-								{
-									"id": "ars",
-									"type": "appearance"
-								}
-							],
-							"categories": [
-								"mistborn",
-								"plan",
-								"forthcoming",
-								"novel"
-							]
-						},
-						{
-							"id": "nicki",
-							"title": "Boatload of Mummies",
-							"title2": "<a target='_blank' href='https://wob.coppermind.net/events/479/#e15159'>Boatload of Mummies</a>",
-							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 2)",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-							"chronology": "Mistborn Era 2 occurs <a target='_blank' href='https://wob.coppermind.net/events/260/#e8747'>after Stormlight Archive book 5</a> and <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>before Stormlight Archive book 6</a>.",
-							"padding": 12,
-							"sorting": {
-								"chronology": 8.5
-							},
-							"categories": [
-								"mistborn",
-								"short",
-								"plan",
-								"unpublished"
-							]
-						}
-					]
-				},
-				{
-					"label": "Mistborn<br>Era 3",
-					"children": [
-						{
-							"id": "mb8",
-							"title": "Mistborn Era 3 Book 1",
-							"title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=mistborn+era+3'>Mistborn Era 3 Book 1</a>",
-							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 3)",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>Fifty to seventy years after Mistborn Era 2. After Stormlight Archive book 10.</a> Prior to Mistborn Era 4.",
-							"publication": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>2024 (best guess)</a>",
-							"sorting": {
-								"chronology": 10.1,
+                            ]
+                        },
+                        {
+                            "id": "tes2",
+                            "title": "The Emperor's Soul sequel",
+                            "title2": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>Untitled Emperor's Soul sequel</a>",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Sel'>Sel</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Selish_system'>Selish system</a>",
+                            "categories": [ "no-series", "plan", "unpublished", "novella" ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "label": "Scadrial",
+            "color": "#9973bf",
+            "children": [
+                {
+                    "label": "Mistborn<br>Era 1",
+                    "children": [
+                        {
+                            "id": "mb1",
+                            "title": "Mistborn: The Final Empire",
+                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn:_The_Final_Empire'>Mistborn: The Final Empire</a>",
+                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 1)",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
+                            "publication": "July 2006",
+                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/176/#e8494'>Mistborn Era 1 occurs prior to The Stormlight Archive.",
+                            "sorting": {
+				"order": 1.11,
+                                "publication": 2006.07,
+                                "chronology": 4.1
+                            },
+                            "appearances": [
+                                {
+                                    "id": "hoid",
+                                    "type": "appearance",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Kelsier'>Kelsier</a> meets with <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> in <a target='_blank' href='https://coppermind.net/wiki/Summary:Mistborn:_The_Final_Empire#Chapter_19'>Chapter 19</a>."
+                                },
+                                {
+                                    "id": "nazh",
+                                    "type": "mention",
+                                    "description": "Annotations by <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> can be found on the map of <a target='_blank' href='https://coppermind.net/wiki/Luthadel'>Luthadel</a>."
+                                },
+                                {
+                                    "id": "ars",
+                                    "type": "appearance"
+                                }
+                            ],
+                            "categories": [ "mistborn", "phase1", "published", "novel" ]
+                        },
+                        {
+                            "id": "11m",
+                            "title": "The Eleventh Metal",
+                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Eleventh_Metal'>The Eleventh Metal</a>",
+                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 1)",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
+                            "au": "Included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
+                            "padding": 12,
+                            "publication": "December 2011",
+                            "chronology": "Concerns Kelsier's training, years before Mistborn: The Final Empire.",
+                            "sorting": {
+				"order": 1.14,
+                                "publication": 2011.12,
+                                "chronology": 4.09
+                            },
+                            "categories": [ "mistborn", "short", "phase1b", "published" ]
+                        },
+                        {
+                            "id": "mb2",
+                            "title": "The Well of Ascension",
+                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Well_of_Ascension'>The Well of Ascension</a>",
+                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 1)",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
+                            "publication": "August 2007",
+                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/176/#e8494'>Mistborn Era 1 occurs prior to The Stormlight Archive.",
+                            "sorting": {
+				"order": 1.12,
+                                "publication": 2007.08,
+                                "chronology": 4.2
+                            },
+                            "appearances": [
+                                {
+                                    "id": "hoid",
+                                    "type": "appearance",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is among the <a target='_blank' href='https://coppermind.net/wiki/Terris'>Terris</a> refugees in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Well_of_Ascension#Chapter_56'>Chapter 56</a>, <a target='_blank' href='https://wob.coppermind.net/events/130/#e1552'>according to Brandon</a>."
+                                },
+                                {
+                                    "id": "nazh",
+                                    "type": "mention",
+                                    "description": "Annotations by <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> can be found on the map of <a target='_blank' href='https://coppermind.net/wiki/Luthadel'>Luthadel</a>."
+                                },
+                                {
+                                    "id": "ars",
+                                    "type": "appearance"
+                                }
+                            ],
+                            "categories": [ "mistborn", "phase1", "published", "novel" ],
+                            "connections": [
+                                {
+                                    "target": "wb",
+                                    "type": "egg",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Lemex%27s_nurse'>Lemex's nurse</a> is a <a target='_blank' href='https://coppermind.net/wiki/Terris'>Terriswoman</a>."
+                                }
+                            ]
+                        },
+                        {
+                            "id": "mb3",
+                            "title": "The Hero of Ages",
+                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Hero_of_Ages'>The Hero of Ages</a>",
+                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 1)",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
+                            "publication": "October 2008",
+                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/176/#e8494'>Mistborn Era 1 occurs prior to The Stormlight Archive.",
+                            "sorting": {
+				"order": 1.13,
+                                "publication": 2008.10,
+                                "chronology": 4.3
+                            },
+                            "appearances": [
+                                {
+                                    "id": "hoid",
+                                    "type": "mention",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is the informant that <a target='_blank' href='https://coppermind.net/wiki/Vin'>Vin</a> was supposed to meet with in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Hero_of_Ages#Chapter_27'>Chapter 27</a>."
+                                },
+                                {
+                                    "id": "nazh",
+                                    "type": "mention",
+                                    "description": "Annotations by <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> can be found on the map of <a target='_blank' href='https://coppermind.net/wiki/Luthadel'>Luthadel</a>."
+                                },
+                                {
+                                    "id": "ars",
+                                    "type": "appearance"
+                                }
+                            ],
+                            "categories": [ "mistborn", "phase1", "published", "novel" ],
+                            "connections": [
+                                {
+                                    "target": "sa1",
+                                    "type": "egg",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Demoux'>Demoux</a> appears in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Way_of_Kings#Interlude_I-1:_Ishikk'>Interlude I-1</a> as 'Thinker'; <a target='_blank' href='https://coppermind.net/wiki/Ishikk'>Ishikk</a> mishears his name as 'Temoo'. <a target='_blank' href='https://coppermind.net/wiki/Ruin'>Ruin</a>'s <a target='_blank' href='https://coppermind.net/wiki/vessel'>vessel</a>, <a target='_blank' href='https://coppermind.net/wiki/Ati'>Ati</a>, is mentioned in the <a target='_blank' href='https://coppermind.net/wiki/https://coppermind.net/wiki/The_Way_of_Kings/Epigraphs#The_Letter'>Chapter 18 epigraph</a>. <a target='_blank' href='https://coppermind.net/wiki/Felt'>Felt</a> worked for the <a target='_blank' href='https://coppermind.net/wiki/House_Venture'>House Venture</a> on <a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>."
+                                },
+                                {
+                                    "target": "sa2",
+                                    "type": "egg",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Wit</a> appears to use <a target='_blank' href='https://coppermind.net/wiki/Allomancy'>emotional Allomancy</a> in <a target='_blank' href='https://coppermind.net/wiki/Summary:Words_of_Radiance#Chapter_45:_Middlefest'>Chapter 45</a>."
+                                },
+                                {
+                                    "target": "sa3",
+                                    "type": "significant",
+                                    "description": "The <a target='_blank' href='https://coppermind.net/wiki/Oathbringer/Epigraphs#Letters'>Part 2 epigraphs</a> include <a target='_blank' href='https://coppermind.net/wiki/Letters#Third_Oathbringer_Letter'>a letter</a> from <a target='_blank' href='https://coppermind.net/wiki/Sazed'>Sazed</a> to <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a>. <a target='_blank' href='https://coppermind.net/wiki/Felt'>Felt</a> reveals he is from another world."
+                                },
+                                {
+                                    "target": "au",
+                                    "type": "major",
+                                    "description": "The <a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a> essay discusses the events that occurred in <a target='_blank' href='https://coppermind.net/wiki/The_Hero_of_Ages'>The Hero of Ages</a>."
+                                },
+                                {
+                                    "target": "sa4",
+                                    "type": "significant",
+                                    "description": "The <a target='_blank' href='https://coppermind.net/wiki/Rhythm_of_War/Epigraphs'>Part 2 Epigraphs</a> are a letter from <a target='_blank' href='https://coppermind.net/wiki/Harmony'>Harmony</a>. <a target='_blank' href='https://coppermind.net/wiki/Fabrial'>Fabrial</a> metals have similar effects as in the <a target='_blank' href='https://coppermind.net/wiki/Metallic_Arts'>Metalic Arts</a>. <a target='_blank' href='https://coppermind.net/wiki/Gereh'>Gereh</a> and <a target='_blank' href='https://coppermind.net/wiki/Axindweth'>Axindweth</a> are <a target='_blank' href='https://coppermind.net/wiki/Feruchemy'>Feruchemists</a>. <a target='_blank' href='https://coppermind.net/wiki/Raysium'>Raysium</a> is associated with <a target='_blank' href='https://coppermind.net/wiki/Odium'>Odium</a> as <a target='_blank' href='https://coppermind.net/wiki/atium'>atium</a> is associated with <a target='_blank' href='https://coppermind.net/wiki/Ruin'>Ruin</a>."
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "label": "Mistborn<br>Era 2",
+                    "children": [
+                        {
+                            "id": "mb4",
+                            "title": "The Alloy of Law",
+                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Alloy_of_Law'>The Alloy of Law</a>",
+                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 2)",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
+                            "publication": "November 2011",
+                            "chronology": "Mistborn Era 2 occurs <a target='_blank' href='https://wob.coppermind.net/events/260/#e8747'>after Stormlight Archive book 5</a> and <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>before Stormlight Archive book 6</a>.",
+                            "sorting": {
+				"order": 2.21,
+                                "publication": 2011.11,
+                                "chronology": 8.1
+                            },
+                            "appearances": [
+                                {
+                                    "id": "hoid",
+                                    "type": "appearance",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is the beggar speaking with <a target='_blank' href='https://coppermind.net/wiki/Joshin_Yomen'>Lord Joshin</a> and <a target='_blank' href='https://coppermind.net/wiki/Mi%27chelle_Yomen'>Lady Mi'chelle</a> in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Alloy_of_Law#Chapter_4'>Chapter 4</a>."
+                                },
+                                {
+                                    "id": "nazh",
+                                    "type": "mention",
+                                    "description": "Annotations by <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> can be found on the map of <a target='_blank' href='https://coppermind.net/wiki/Elendel'>Elendel</a>."
+                                },
+                                {
+                                    "id": "ars",
+                                    "type": "appearance"
+                                }
+                            ],
+                            "categories": [ "mistborn", "phase2", "published", "novel" ]
+                        },
+                        {
+                            "id": "jak",
+                            "title": "Allomancer Jak",
+                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Allomancer_Jak_and_the_Pits_of_Eltania'>Allomancer Jak and the Pits of Eltania</a>",
+                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 2)",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
+                            "au": "Included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
+                            "padding": 12,
+                            "publication": "August 2014",
+                            "chronology": "Mistborn Era 2 occurs <a target='_blank' href='https://wob.coppermind.net/events/260/#e8747'>after Stormlight Archive book 5</a> and <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>before Stormlight Archive book 6</a>.",
+                            "sorting": {
+				"order": 2.22,
+                                "publication": 2014.08,
+                                "chronology": 8.05
+                            },
+                            "categories": [ "mistborn", "short", "phase2b", "published" ]
+                        },
+                        {
+                            "id": "mb5",
+                            "title": "Shadows of Self",
+                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Shadows_of_Self'>Shadows of Self</a>",
+                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 2)",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
+                            "publication": "October 2015",
+                            "chronology": "Mistborn Era 2 occurs <a target='_blank' href='https://wob.coppermind.net/events/260/#e8747'>after Stormlight Archive book 5</a> and <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>before Stormlight Archive book 6</a>.",
+                            "sorting": {
+				"order": 2.23,
+                                "publication": 2015.10,
+                                "chronology": 8.2
+                            },
+                            "appearances": [
+                                {
+                                    "id": "hoid",
+                                    "type": "appearance",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is <a target='_blank' href='https://coppermind.net/wiki/Waxillium_Laddrian'>Wax</a>'s coachman, named in <a target='_blank' href='https://coppermind.net/wiki/Summary:Shadows_of_Self#Chapter_7'>Chapter 7</a>."
+                                },
+                                {
+                                    "id": "ars",
+                                    "type": "appearance"
+                                }
+                            ],
+                            "categories": [ "mistborn", "phase2", "published", "novel" ]
+                        },
+                        {
+                            "id": "mb6",
+                            "title": "The Bands of Mourning",
+                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Bands_of_Mourning'>The Bands of Mourning</a>",
+                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 2)",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
+                            "publication": "January 2016",
+                            "chronology": "Mistborn Era 2 occurs <a target='_blank' href='https://wob.coppermind.net/events/260/#e8747'>after Stormlight Archive book 5</a> and <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>before Stormlight Archive book 6</a>.",
+                            "sorting": {
+				"order": 2.24,
+                                "publication": 2016.01,
+                                "chronology": 8.3
+                            },
+                            "appearances": [
+                                {
+                                    "id": "hoid",
+                                    "type": "appearance",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is the beggar who gives <a target='_blank' href='https://coppermind.net/wiki/Waxillium_Laddrian'>Wax</a> a special coin in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Bands_of_Mourning#Chapter_11'>Chapter 11</a>."
+                                },
+                                {
+                                    "id": "khriss",
+                                    "type": "appearance",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> is the woman who dances with <a target='_blank' href='https://coppermind.net/wiki/Waxillium_Laddrian'>Wax</a> in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Bands_of_Mourning#Chapter_12'>Chapter 12</a>. <a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> and <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> are also the 'K or N' referred to in the 'Do your metal tools speak to you?' ad in <a target='_blank' href='https://coppermind.net/wiki/The_New_Ascendancy'>The New Ascendancy</a> broadsheet."
+                                },
+                                {
+                                    "id": "nazh",
+                                    "type": "mention",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> is 'the haunted man' in 'The Ghastly Gondola!' story in <a target='_blank' href='https://coppermind.net/wiki/The_New_Ascendancy'>The New Ascendancy</a> broadsheet. (note his 'shadows' curse) <a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> and <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> are also the 'K or N' referred to in the 'Do your metal tools speak to you?' ad in the broadsheet."
+                                },
+                                {
+                                    "id": "ars",
+                                    "type": "appearance"
+                                }
+                            ],
+                            "categories": [ "mistborn", "phase2", "published", "novel" ],
+                            "connections": [
+                                {
+                                    "target": "sa2",
+                                    "type": "egg",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Iyatil'>Iyatil</a> is of <a target='_blank' href='https://coppermind.net/wiki/Southern_Scadrial'>Southern Scadrian</a> descent."
+                                },
+                                {
+                                    "target": "msh",
+                                    "type": "major",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Kelsier'>Kelsier</a>'s survival is revealed in <a target='_blank' href='https://coppermind.net/wiki/The_Bands_of_Mourning'>The Bands of Mourning</a>."
+                                },
+                                {
+                                    "target": "sotd2",
+                                    "type": "minor",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrian</a> spaceships powered by <a target='_blank' href='https://coppermind.net/wiki/Allomancy'>Allomancy</a> are seen."
+                                }
+                            ]
+                        },
+                        {
+                            "id": "mb7",
+                            "title": "The Lost Metal (2022)",
+                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Lost_Metal'>The Lost Metal</a>",
+                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 2)",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
+                            "publication": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>Fall 2022</a>",
+                            "chronology": "Mistborn Era 2 occurs <a target='_blank' href='https://wob.coppermind.net/events/260/#e8747'>after Stormlight Archive book 5</a> and <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>before Stormlight Archive book 6</a>.",
+                            "sorting": {
+                                "publication": 2022.11,
+                                "chronology": 8.4
+                            },
+                            "appearances": [
+                                {
+                                    "id": "hoid",
+                                    "type": "appearance",
+                                    "description": "WIP"
+                                },
+                                {
+                                    "id": "nazh",
+                                    "type": "mention",
+                                    "description": "WIP"
+                                },
+                                {
+                                    "id": "ars",
+                                    "type": "appearance"
+                                }
+                            ],
+                            "categories": [ "mistborn", "plan", "forthcoming", "novel" ]
+                        },
+                        {
+                            "id": "nicki",
+                            "title": "Boatload of Mummies",
+                            "title2": "<a target='_blank' href='https://wob.coppermind.net/events/479/#e15159'>Boatload of Mummies</a>",
+                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 2)",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
+                            "chronology": "Mistborn Era 2 occurs <a target='_blank' href='https://wob.coppermind.net/events/260/#e8747'>after Stormlight Archive book 5</a> and <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>before Stormlight Archive book 6</a>.",
+                            "padding": 12,
+                            "sorting": {
+                                "chronology": 8.5
+                            },
+                            "categories": [ "mistborn", "short", "plan", "unpublished" ]
+                        }
+                    ]
+                },
+                {
+                    "label": "Mistborn<br>Era 3",
+                    "children": [
+                        {
+                            "id": "mb8",
+                            "title": "Mistborn Era 3 Book 1",
+                            "title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=mistborn+era+3'>Mistborn Era 3 Book 1</a>",
+                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 3)",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
+                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>Fifty to seventy years after Mistborn Era 2. After Stormlight Archive book 10.</a> Prior to Mistborn Era 4.",
+                            "publication": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>2024 (best guess)</a>",
+                            "sorting": {
+                                "chronology": 10.1,
 								"publication": 2024
-							},
-							"categories": [
-								"mistborn",
-								"plan",
-								"unpublished",
-								"novel"
-							]
-						},
-						{
-							"id": "mb9",
-							"title": "Mistborn Era 3 Book 2",
-							"title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=mistborn+era+3'>Mistborn Era 3 Book 2</a>",
-							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 3)",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>Fifty to seventy years after Mistborn Era 2. After Stormlight Archive book 10.</a> Prior to Mistborn Era 4.",
-							"publication": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>2025 (best guess)</a>",
-							"sorting": {
-								"chronology": 10.2,
+                            },
+                            "categories": [ "mistborn", "plan", "unpublished", "novel" ]
+                        },
+                        {
+                            "id": "mb9",
+                            "title": "Mistborn Era 3 Book 2",
+                            "title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=mistborn+era+3'>Mistborn Era 3 Book 2</a>",
+                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 3)",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
+                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>Fifty to seventy years after Mistborn Era 2. After Stormlight Archive book 10.</a> Prior to Mistborn Era 4.",
+                            "publication": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>2025 (best guess)</a>",
+                            "sorting": {
+                                "chronology": 10.2,
 								"publication": 2025
-							},
-							"categories": [
-								"mistborn",
-								"plan",
-								"unpublished",
-								"novel"
-							]
-						},
-						{
-							"id": "mb10",
-							"title": "Mistborn Era 3 Book 3",
-							"title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=mistborn+era+3'>Mistborn Era 3 Book 3</a>",
-							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 3)",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>Fifty to seventy years after Mistborn Era 2. After Stormlight Archive book 10.</a> Prior to Mistborn Era 4.",
-							"publication": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>2026 (best guess)</a>",
-							"sorting": {
-								"chronology": 10.3,
+                            },
+                            "categories": [ "mistborn", "plan", "unpublished", "novel" ]
+                        },
+                        {
+                            "id": "mb10",
+                            "title": "Mistborn Era 3 Book 3",
+                            "title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=mistborn+era+3'>Mistborn Era 3 Book 3</a>",
+                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 3)",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
+                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>Fifty to seventy years after Mistborn Era 2. After Stormlight Archive book 10.</a> Prior to Mistborn Era 4.",
+                            "publication": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>2026 (best guess)</a>",
+                            "sorting": {
+                                "chronology": 10.3,
 								"publication": 2026
-							},
-							"categories": [
-								"mistborn",
-								"plan",
-								"unpublished",
-								"novel"
-							]
-						}
-					]
-				},
+                            },
+                            "categories": [ "mistborn", "plan", "unpublished", "novel" ]
+                        }
+                    ]
+                },
+                {
+                    "label": "Mistborn<br>Era 4",
+                    "children": [
+                        {
+                            "id": "mb11",
+                            "title": "Mistborn Era 4 Book 1",
+                            "title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=mistborn+era+4'>Mistborn Era 4 Book 1</a>",
+                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 4)",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
+                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/182/#e3884'>Mistborn Era 4 is the finale of the cosmere storyline.</a>",
+                            "sorting": {
+                                "chronology": 13.1
+                            },
+                            "categories": [ "mistborn", "plan", "unpublished", "novel" ]
+                        },
+                        {
+                            "id": "mb12",
+                            "title": "Mistborn Era 4 Book 2",
+                            "title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=mistborn+era+4'>Mistborn Era 4 Book 2</a>",
+                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 4)",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
+                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/182/#e3884'>Mistborn Era 4 is the finale of the cosmere storyline.</a>",
+                            "sorting": {
+                                "chronology": 13.2
+                            },
+                            "categories": [ "mistborn", "plan", "unpublished", "novel" ]
+                        },
+                        {
+                            "id": "mb13",
+                            "title": "Mistborn Era 4 Book 3",
+                            "title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=mistborn+era+4'>Mistborn Era 4 Book 3</a>",
+                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 4)",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
+                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/182/#e3884'>Mistborn Era 4 is the finale of the cosmere storyline.</a>",
+                            "sorting": {
+                                "chronology": 13.3
+                            },
+                            "categories": [ "mistborn", "plan", "unpublished", "novel" ]
+                        }
+                    ]
+                },
+                {
+                    "label": "Other<br>Mistborn",
+                    "children": [
+                        {
+                            "id": "msh",
+                            "title": "Mistborn: Secret History",
+                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn:_Secret_History'>Mistborn: Secret History</a>",
+                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a>",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
+                            "au": "Included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
+                            "publication": "January 2016",
+                            "chronology": "Happens concurrently with Mistborn Era 1.",
+                            "sorting": {
+				"order": 2.25,
+                                "publication": 2016.01,
+                                "chronology": 4.11
+                            },
+                            "appearances": [
+                                {
+                                    "id": "hoid",
+                                    "type": "appearance",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is 'Drifter'."
+                                },
+                                {
+                                    "id": "khriss",
+                                    "type": "appearance",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Kelsier'>Kelsier</a> meets <a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> and <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> in the <a target='_blank' href='https://coppermind.net/wiki/Cognitive_Realm'>Cognitive Realm</a>."
+                                },
+                                {
+                                    "id": "nazh",
+                                    "type": "appearance",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Kelsier'>Kelsier</a> meets <a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> and <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> in the <a target='_blank' href='https://coppermind.net/wiki/Cognitive_Realm'>Cognitive Realm</a>."
+                                }
+                            ],
+                            "categories": [ "mistborn", "novella", "phase2", "published" ],
+                            "connections": [
+                                {
+                                    "target": "sa1",
+                                    "type": "egg",
+                                    "description": "In <a target='_blank' href='https://coppermind.net/wiki/Summary:Mistborn:_Secret_History#Chapter_2_5'>Part 5 Chapter 2</a> <a target='_blank' href='https://coppermind.net/wiki/Kelsier'>Kelsier</a> sees an <a target='_blank' href='https://coppermind.net/wiki/Fabrial'>alerter fabrial</a> (the glowing yellow gemstone in a golden metal lattice)."
+                                },
+                                {
+                                    "target": "sa2",
+                                    "type": "egg",
+                                    "description": "With powers gained from the <a target='_blank' href='https://coppermind.net/wiki/lerasium'>lerasium</a> he took, <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> uses <a target='_blank' href='https://coppermind.net/wiki/Allomancy'>emotional Allomancy</a> in <a target='_blank' href='https://coppermind.net/wiki/Summary:Words_of_Radiance#Chapter_45:_Middlefest'>Chapter 45</a>."
+                                },
+                                {
+                                    "target": "traveler",
+                                    "type": "major",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> and <a target='_blank' href='https://coppermind.net/wiki/Frost'>Frost</a> discuss the events of <a target='_blank' href='https://coppermind.net/wiki/The_Hero_of_Ages'>The Hero of Ages</a> (and <a target='_blank' href='https://coppermind.net/wiki/Mistborn:_Secret_History'>Mistborn: Secret History</a>)."
+                                },
+                                {
+                                    "target": "sa4",
+                                    "type": "significant",
+                                    "description": "Thaidakar, leader of the <a target='_blank' href='https://coppermind.net/wiki/Ghostbloods'>Ghostbloods</a> is <a target='_blank' href='https://coppermind.net/wiki/Kelsier'>Kelsier</a>, with the fight between him and <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> in <a target='_blank' href='https://coppermind.net/wiki/Mistborn:_Secret_History'>Secret History</a> specifically referenced. <a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a> is referenced in <a target='_blank' href='https://coppermind.net/wiki/Ialai'>Ialai's</a> notes. The device used by the <a target='_blank' href='https://coppermind.net/wiki/honorspren'>honorspren</a> to store <a target='_blank' href='https://coppermind.net/wiki/Stormlight'>Stormlight</a> came from the <a target='_blank' href='https://coppermind.net/wiki/Ire'>Ire</a>."
+                                },
 				{
-					"label": "Mistborn<br>Era 4",
-					"children": [
-						{
-							"id": "mb11",
-							"title": "Mistborn Era 4 Book 1",
-							"title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=mistborn+era+4'>Mistborn Era 4 Book 1</a>",
-							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 4)",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/182/#e3884'>Mistborn Era 4 is the finale of the cosmere storyline.</a>",
-							"sorting": {
-								"chronology": 13.1
-							},
-							"categories": [
-								"mistborn",
-								"plan",
-								"unpublished",
-								"novel"
-							]
-						},
-						{
-							"id": "mb12",
-							"title": "Mistborn Era 4 Book 2",
-							"title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=mistborn+era+4'>Mistborn Era 4 Book 2</a>",
-							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 4)",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/182/#e3884'>Mistborn Era 4 is the finale of the cosmere storyline.</a>",
-							"sorting": {
-								"chronology": 13.2
-							},
-							"categories": [
-								"mistborn",
-								"plan",
-								"unpublished",
-								"novel"
-							]
-						},
-						{
-							"id": "mb13",
-							"title": "Mistborn Era 4 Book 3",
-							"title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=mistborn+era+4'>Mistborn Era 4 Book 3</a>",
-							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 4)",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/182/#e3884'>Mistborn Era 4 is the finale of the cosmere storyline.</a>",
-							"sorting": {
-								"chronology": 13.3
-							},
-							"categories": [
-								"mistborn",
-								"plan",
-								"unpublished",
-								"novel"
-							]
-						}
-					]
-				},
-				{
-					"label": "Other<br>Mistborn",
-					"children": [
-						{
-							"id": "msh",
-							"title": "Mistborn: Secret History",
-							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn:_Secret_History'>Mistborn: Secret History</a>",
-							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a>",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-							"au": "Included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
-							"publication": "January 2016",
-							"chronology": "Happens concurrently with Mistborn Era 1.",
-							"sorting": {
-								"order": 2.25,
-								"publication": 2016.01,
-								"chronology": 4.11
-							},
-							"appearances": [
-								{
-									"id": "hoid",
-									"type": "appearance",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is 'Drifter'."
-								},
-								{
-									"id": "khriss",
-									"type": "appearance",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Kelsier'>Kelsier</a> meets <a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> and <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> in the <a target='_blank' href='https://coppermind.net/wiki/Cognitive_Realm'>Cognitive Realm</a>."
-								},
-								{
-									"id": "nazh",
-									"type": "appearance",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Kelsier'>Kelsier</a> meets <a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> and <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> in the <a target='_blank' href='https://coppermind.net/wiki/Cognitive_Realm'>Cognitive Realm</a>."
-								}
-							],
-							"categories": [
-								"mistborn",
-								"novella",
-								"phase2",
-								"published"
-							],
-							"connections": [
-								{
-									"target": "sa1",
-									"type": "egg",
-									"description": "In <a target='_blank' href='https://coppermind.net/wiki/Summary:Mistborn:_Secret_History#Chapter_2_5'>Part 5 Chapter 2</a> <a target='_blank' href='https://coppermind.net/wiki/Kelsier'>Kelsier</a> sees an <a target='_blank' href='https://coppermind.net/wiki/Fabrial'>alerter fabrial</a> (the glowing yellow gemstone in a golden metal lattice)."
-								},
-								{
-									"target": "sa2",
-									"type": "egg",
-									"description": "With powers gained from the <a target='_blank' href='https://coppermind.net/wiki/lerasium'>lerasium</a> he took, <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> uses <a target='_blank' href='https://coppermind.net/wiki/Allomancy'>emotional Allomancy</a> in <a target='_blank' href='https://coppermind.net/wiki/Summary:Words_of_Radiance#Chapter_45:_Middlefest'>Chapter 45</a>."
-								},
-								{
-									"target": "traveler",
-									"type": "major",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> and <a target='_blank' href='https://coppermind.net/wiki/Frost'>Frost</a> discuss the events of <a target='_blank' href='https://coppermind.net/wiki/The_Hero_of_Ages'>The Hero of Ages</a> (and <a target='_blank' href='https://coppermind.net/wiki/Mistborn:_Secret_History'>Mistborn: Secret History</a>)."
-								},
-								{
-									"target": "sa4",
-									"type": "significant",
-									"description": "Thaidakar, leader of the <a target='_blank' href='https://coppermind.net/wiki/Ghostbloods'>Ghostbloods</a> is <a target='_blank' href='https://coppermind.net/wiki/Kelsier'>Kelsier</a>, with the fight between him and <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> in <a target='_blank' href='https://coppermind.net/wiki/Mistborn:_Secret_History'>Secret History</a> specifically referenced. <a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a> is referenced in <a target='_blank' href='https://coppermind.net/wiki/Ialai'>Ialai's</a> notes. The device used by the <a target='_blank' href='https://coppermind.net/wiki/honorspren'>honorspren</a> to store <a target='_blank' href='https://coppermind.net/wiki/Stormlight'>Stormlight</a> came from the <a target='_blank' href='https://coppermind.net/wiki/Ire'>Ire</a>."
-								},
-								{
-									"target": "mb7",
-									"type": "significant",
-									"description": "(WIP) Kelsier's survival is made explicit in Secret History. The glowing jars that the Ire are using are likely purified Dor."
-								}
-							]
-						},
-						{
-							"id": "msh2",
-							"title": "Mistborn: Secret History 2",
-							"title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=mistborn%3A+secret+history+2'>Mistborn: Secret History 2</a>",
-							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a>",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-							"categories": [
-								"mistborn",
-								"novella",
-								"plan",
-								"unpublished"
-							]
-						},
-						{
-							"id": "mb-cyberpunk",
-							"title": "Cyberpunk Mistborn",
-							"title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?query=cyberpunk%2Bmistborn&date_from=2003-12-05&date_to=2019-11-20&speaker=&ordering=rank'>Cyberpunk Mistborn</a>",
-							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a>",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-							"chronology": "A cyberpunk Mistborn series would be in a <a target='_blank' href='https://wob.coppermind.net/events/34/#e1782'>near-future setting</a>, between Eras 3 and 4.",
-							"sorting": {
-								"chronology": 10.7
-							},
-							"categories": [
-								"mistborn",
-								"plan",
-								"unpublished",
-								"novel"
-							]
-						}
-					]
+				    "target": "mb7",
+				    "type": "significant",
+				    "description": "WIP"
 				}
-			]
-		},
-		{
-			"label": "Nalthis",
-			"color": "#de4343",
-			"children": [
+                            ]
+                        },
+                        {
+                            "id": "msh2",
+                            "title": "Mistborn: Secret History 2",
+                            "title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=mistborn%3A+secret+history+2'>Mistborn: Secret History 2</a>",
+                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a>",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
+                            "categories": [ "mistborn", "novella", "plan", "unpublished" ]
+                        },
+						{
+                            "id": "mb-cyberpunk",
+                            "title": "Cyberpunk Mistborn",
+                            "title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?query=cyberpunk%2Bmistborn&date_from=2003-12-05&date_to=2019-11-20&speaker=&ordering=rank'>Cyberpunk Mistborn</a>",
+                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a>",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
+                            "chronology": "A cyberpunk Mistborn series would be in a <a target='_blank' href='https://wob.coppermind.net/events/34/#e1782'>near-future setting</a>, between Eras 3 and 4.",
+                            "sorting": {
+                                "chronology": 10.7
+                            },
+                            "categories": [ "mistborn", "plan", "unpublished", "novel" ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "label": "Nalthis",
+            "color": "#de4343",
+            "children": [
+                {
+                    "label": "Warbreaker",
+                    "color": "#de4343",
+                    "children": [
+                        {
+                            "id": "wb",
+                            "title": "Warbreaker",
+                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Warbreaker'>Warbreaker</a>",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Nalthis'>Nalthis</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Nalthian_system'>Nalthian system</a>",
+                            "publication": "June 2009",
+                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/309/#e10273'>Occurs after Mistborn Era 1 and before The Stormlight Archive.</a>",
+                            "link": "Full text: <a target='_blank' href='https://www.brandonsanderson.com/warbreaker-rights-and-downloads/'>Brandon's website</a> | <a target='_blank' href='https://github.com/guusj/books'>Alternate file types</a>",
+			    "sorting": {
+				"order": 1.2,
+                                "publication": 2009.06,
+                                "chronology": 5.1
+                            },
+                            "appearances": [
+                                {
+                                    "id": "hoid",
+                                    "type": "appearance",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is the master storyteller in <a target='_blank' href='https://coppermind.net/wiki/Summary:Warbreaker#Chapter_32'>Chapter 32</a>."
+                                },
+                                {
+                                    "id": "ars",
+                                    "type": "appearance"
+                                }
+                            ],
+                            "categories": [ "warbreaker", "phase1", "published", "novel" ],
+                            "connections": [
+                                {
+                                    "target": "sa2",
+                                    "type": "significant",
+                                    "description": "Zahel is <a target='_blank' href='https://coppermind.net/wiki/Vasher'>Vasher</a>. <a target='_blank' href='https://coppermind.net/wiki/Szeth'>Szeth</a>'s new <a target='_blank' href='https://coppermind.net/wiki/Shardblade'>Shardblade</a> is <a target='_blank' href='https://coppermind.net/wiki/Nightblood'>Nightblood</a>. <a target='_blank' href='https://coppermind.net/wiki/Mraize'>Mraize</a>'s collection in <a target='_blank' href='https://coppermind.net/wiki/Summary:Words_of_Radiance#Chapter_43:_The_Ghostbloods'>Chapter 43</a> includes a <a target='_blank' href='https://coppermind.net/wiki/Tears_of_Edgli'>Tear of Edgli</a> flower."
+                                },
+                                {
+                                    "target": "sa3",
+                                    "type": "major",
+                                    "description": "Azure is <a target='_blank' href='https://coppermind.net/wiki/Vivenna'>Vivenna</a>; she uses <a target='_blank' href='https://coppermind.net/wiki/Awakening'>Awakening</a> on several occaisions and has an Awakened sword. <a target='_blank' href='https://coppermind.net/wiki/Nightblood'>Nightblood</a> and <a target='_blank' href='https://coppermind.net/wiki/Vasher'>Vasher</a> make significant appearances. <a target='_blank' href='https://coppermind.net/wiki/Nightblood'>Nightblood</a> mentions <a target='_blank' href='https://coppermind.net/wiki/Denth'>Denth</a>, <a target='_blank' href='https://coppermind.net/wiki/Shashara'>Shashara</a>, and <a target='_blank' href='https://coppermind.net/wiki/Vivenna'>Vivenna</a> by name. A painting from the <a target='_blank' href='https://coppermind.net/wiki/Court_of_Gods'>Court of Gods</a> appears in <a target='_blank' href='https://coppermind.net/wiki/Summary:Oathbringer#Chapter_102:_Celebrant'>Chapter 102</a>. <a target='_blank' href='https://coppermind.net/wiki/Riino'>Riino</a> mentions <a target='_blank' href='https://coppermind.net/wiki/Heightening'>Heightenings</a>. <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> uses <a target='_blank' href='https://coppermind.net/wiki/Awakening'>Awakening</a> in the <a target='_blank' href='https://coppermind.net/wiki/Summary:Oathbringer#Epilogue:_Great_Art'>Epilogue</a>."
+                                },
+								{
+                                    "target": "sa3.5",
+                                    "type": "minor",
+                                    "description": "The <a target='_blank' href='https://coppermind.net/wiki/Dawnshard'>Dawnshard</a> causes <a target='_blank' href='https://coppermind.net/wiki/Rysn_Ftori'>Rysn</a> to experience several effects similar to the <a target='_blank' href='https://coppermind.net/wiki/BioChromatic_Breath'>Heightenings associated with Breath</a>."
+                                },
+								{
+                                    "target": "sa4",
+                                    "type": "major",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Nightblood'>Nightblood</a> is used to kill <a target='_blank' href='https://coppermind.net/wiki/Rayse'>Rayse</a>. <a target='_blank' href='https://coppermind.net/wiki/Ialai'>Ialai's</a> notes mention <a target='_blank' href='https://coppermind.net/wiki/Nalthis'>Nalthis</a>. <a target='_blank' href='https://coppermind.net/wiki/Zahel'>Zahel</a> uses <a target='_blank' href='https://coppermind.net/wiki/Awakening'>Awakening</a> in his fight against <a target='_blank' href='https://coppermind.net/wiki/Kaladin'>Kaladin</a> and explains that he is a <a target='_blank' href='https://coppermind.net/wiki/Cognitive_Shadow'>Cognitive Shadow</a>. The coin <a target='_blank' href='https://coppermind.net/wiki/Adolin'>Adolin</a> gives to <a target='_blank' href='https://coppermind.net/wiki/Kaladin'>Kaladin</a> and some merchants in <a target='_blank' href='https://coppermind.net/wiki/Lasting_Integrity'>Lasting Integrity</a> are from <a target='_blank' href='https://coppermind.net/wiki/Nalthis'>Nalthis</a>. <a target='_blank' href='https://coppermind.net/wiki/Endowment'>Endowment</a> is referenced in the <a target='_blank' href='https://coppermind.net/wiki/Rhythm_of_War/Epigraphs'>Chapter 24 epigraph</a>. <a target='_blank' href='https://coppermind.net/wiki/Odium'>Odium</a> tampers with <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid's</a> <a target='_blank' href='https://coppermind.net/wiki/BioChromatic_Breath'>Breath</a> in the Epilogue."
+                                },
 				{
-					"label": "Warbreaker",
-					"color": "#de4343",
-					"children": [
-						{
-							"id": "wb",
-							"title": "Warbreaker",
-							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Warbreaker'>Warbreaker</a>",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Nalthis'>Nalthis</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Nalthian_system'>Nalthian system</a>",
-							"publication": "June 2009",
-							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/309/#e10273'>Occurs after Mistborn Era 1 and before The Stormlight Archive.</a>",
-							"link": "Full text: <a target='_blank' href='https://www.brandonsanderson.com/warbreaker-rights-and-downloads/'>Brandon's website</a> | <a target='_blank' href='https://github.com/guusj/books'>Alternate file types</a>",
-							"sorting": {
-								"order": 1.2,
-								"publication": 2009.06,
-								"chronology": 5.1
-							},
-							"appearances": [
-								{
-									"id": "hoid",
-									"type": "appearance",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is the master storyteller in <a target='_blank' href='https://coppermind.net/wiki/Summary:Warbreaker#Chapter_32'>Chapter 32</a>."
-								},
-								{
-									"id": "ars",
-									"type": "appearance"
-								}
-							],
-							"categories": [
-								"warbreaker",
-								"phase1",
-								"published",
-								"novel"
-							],
-							"connections": [
-								{
-									"target": "sa2",
-									"type": "significant",
-									"description": "Zahel is <a target='_blank' href='https://coppermind.net/wiki/Vasher'>Vasher</a>. <a target='_blank' href='https://coppermind.net/wiki/Szeth'>Szeth</a>'s new <a target='_blank' href='https://coppermind.net/wiki/Shardblade'>Shardblade</a> is <a target='_blank' href='https://coppermind.net/wiki/Nightblood'>Nightblood</a>. <a target='_blank' href='https://coppermind.net/wiki/Mraize'>Mraize</a>'s collection in <a target='_blank' href='https://coppermind.net/wiki/Summary:Words_of_Radiance#Chapter_43:_The_Ghostbloods'>Chapter 43</a> includes a <a target='_blank' href='https://coppermind.net/wiki/Tears_of_Edgli'>Tear of Edgli</a> flower."
-								},
-								{
-									"target": "sa3",
-									"type": "major",
-									"description": "Azure is <a target='_blank' href='https://coppermind.net/wiki/Vivenna'>Vivenna</a>; she uses <a target='_blank' href='https://coppermind.net/wiki/Awakening'>Awakening</a> on several occaisions and has an Awakened sword. <a target='_blank' href='https://coppermind.net/wiki/Nightblood'>Nightblood</a> and <a target='_blank' href='https://coppermind.net/wiki/Vasher'>Vasher</a> make significant appearances. <a target='_blank' href='https://coppermind.net/wiki/Nightblood'>Nightblood</a> mentions <a target='_blank' href='https://coppermind.net/wiki/Denth'>Denth</a>, <a target='_blank' href='https://coppermind.net/wiki/Shashara'>Shashara</a>, and <a target='_blank' href='https://coppermind.net/wiki/Vivenna'>Vivenna</a> by name. A painting from the <a target='_blank' href='https://coppermind.net/wiki/Court_of_Gods'>Court of Gods</a> appears in <a target='_blank' href='https://coppermind.net/wiki/Summary:Oathbringer#Chapter_102:_Celebrant'>Chapter 102</a>. <a target='_blank' href='https://coppermind.net/wiki/Riino'>Riino</a> mentions <a target='_blank' href='https://coppermind.net/wiki/Heightening'>Heightenings</a>. <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> uses <a target='_blank' href='https://coppermind.net/wiki/Awakening'>Awakening</a> in the <a target='_blank' href='https://coppermind.net/wiki/Summary:Oathbringer#Epilogue:_Great_Art'>Epilogue</a>."
-								},
-								{
-									"target": "sa3.5",
-									"type": "minor",
-									"description": "The <a target='_blank' href='https://coppermind.net/wiki/Dawnshard'>Dawnshard</a> causes <a target='_blank' href='https://coppermind.net/wiki/Rysn_Ftori'>Rysn</a> to experience several effects similar to the <a target='_blank' href='https://coppermind.net/wiki/BioChromatic_Breath'>Heightenings associated with Breath</a>."
-								},
-								{
-									"target": "sa4",
-									"type": "major",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Nightblood'>Nightblood</a> is used to kill <a target='_blank' href='https://coppermind.net/wiki/Rayse'>Rayse</a>. <a target='_blank' href='https://coppermind.net/wiki/Ialai'>Ialai's</a> notes mention <a target='_blank' href='https://coppermind.net/wiki/Nalthis'>Nalthis</a>. <a target='_blank' href='https://coppermind.net/wiki/Zahel'>Zahel</a> uses <a target='_blank' href='https://coppermind.net/wiki/Awakening'>Awakening</a> in his fight against <a target='_blank' href='https://coppermind.net/wiki/Kaladin'>Kaladin</a> and explains that he is a <a target='_blank' href='https://coppermind.net/wiki/Cognitive_Shadow'>Cognitive Shadow</a>. The coin <a target='_blank' href='https://coppermind.net/wiki/Adolin'>Adolin</a> gives to <a target='_blank' href='https://coppermind.net/wiki/Kaladin'>Kaladin</a> and some merchants in <a target='_blank' href='https://coppermind.net/wiki/Lasting_Integrity'>Lasting Integrity</a> are from <a target='_blank' href='https://coppermind.net/wiki/Nalthis'>Nalthis</a>. <a target='_blank' href='https://coppermind.net/wiki/Endowment'>Endowment</a> is referenced in the <a target='_blank' href='https://coppermind.net/wiki/Rhythm_of_War/Epigraphs'>Chapter 24 epigraph</a>. <a target='_blank' href='https://coppermind.net/wiki/Odium'>Odium</a> tampers with <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid's</a> <a target='_blank' href='https://coppermind.net/wiki/BioChromatic_Breath'>Breath</a> in the Epilogue."
-								},
-								{
-									"target": "mb7",
-									"type": "minor",
-									"description": "(WIP) Nalthis is mentionned in chapter 39. Use of an Awakened lock in chapter 40."
-								}
-							]
-						},
-						{
-							"id": "nb",
-							"title": "Nightblood",
-							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Nightblood_(book)'>Nightblood</a>",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Nalthis'>Nalthis</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Nalthian_system'>Nalthian system</a>",
-							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/87/#e5657'>This sequel occurs prior to The Stormlight Archive.</a>",
-							"sorting": {
-								"chronology": 5.2
-							},
-							"categories": [
-								"warbreaker",
-								"plan",
-								"unpublished",
-								"novel"
-							]
-						}
-					]
+				    "target": "mb7",
+				    "type": "significant",
+				    "description": "WIP"
 				}
-			]
-		},
-		{
-			"label": "Roshar",
-			"color": "#2aa1d4",
-			"children": [
+                            ]
+                        },
+                        {
+                            "id": "nb",
+                            "title": "Nightblood",
+                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Nightblood_(book)'>Nightblood</a>",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Nalthis'>Nalthis</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Nalthian_system'>Nalthian system</a>",
+                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/87/#e5657'>This sequel occurs prior to The Stormlight Archive.</a>",
+                            "sorting": {
+                                "chronology": 5.2
+                            },
+                            "categories": [ "warbreaker", "plan", "unpublished", "novel" ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "label": "Roshar",
+            "color": "#2aa1d4",
+            "children": [
+                {
+                    "label": "The Stormlight Archive",
+                    "children": [
+                        {
+                            "id": "sa1",
+                            "title": "The Way of Kings",
+                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Way_of_Kings'>The Way of Kings</a>",
+                            "series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+                            "publication": "August 2010",
+                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/309/#e10273'>Occurs after Mistborn Era 1 and Warbreaker but before Mistborn Era 2.</a>",
+                            "sorting": {
+				"order": 2.41,
+                                "publication": 2010.08,
+                                "chronology": 7.01
+                            },
+                            "appearances": [
+                                {
+                                    "id": "hoid",
+                                    "type": "appearance",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is 'Wit'."
+                                },
+                                {
+                                    "id": "ars",
+                                    "type": "appearance"
+                                }
+                            ],
+                            "categories": [ "stormlight", "phase2", "published", "novel" ]
+                        },
+                        {
+                            "id": "sa2",
+                            "title": "Words of Radiance",
+                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Words_of_Radiance'>Words of Radiance</a>",
+                            "series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+                            "publication": "March 2014",
+                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/309/#e10273'>Occurs after Mistborn Era 1 and Warbreaker but before Mistborn Era 2.</a>",
+                            "sorting": {
+				"order": 2.42,
+                                "publication": 2014.03,
+                                "chronology": 7.02
+                            },
+                            "appearances": [
+                                {
+                                    "id": "hoid",
+                                    "type": "appearance",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is 'Wit'."
+                                },
+                                {
+                                    "id": "nazh",
+                                    "type": "appearance",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> is the <a target='_blank' href='https://coppermind.net/wiki/Ardent'>ardent</a> trying to get a sketch of <a target='_blank' href='https://coppermind.net/wiki/Bridge_Four'>Bridge Four</a>'s tattoo in <a target='_blank' href='https://coppermind.net/wiki/Summary:Words_of_Radiance#Chapter_31:_The_Stillness_Before'>Chapter 31</a>. Several drawings and sketches also include his annotations."
+                                },
+                                {
+                                    "id": "ars",
+                                    "type": "appearance"
+                                }
+                            ],
+                            "categories": [ "stormlight", "phase2", "published", "novel" ],
+                            "connections": [
+                                {
+                                    "target": "jasnah",
+                                    "type": "major",
+                                    "description": "A deleted scene about <a target='_blank' href='https://coppermind.net/wiki/Jasnah_Kholin'>Jasnah</a> that contains some canonical elements."
+                                },
+                                {
+                                    "target": "traveler",
+                                    "type": "minor",
+                                    "description": "The man <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> speaks with is <a target='_blank' href='https://coppermind.net/wiki/Frost'>Frost</a>, who responded to <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> with similar opinions in the <a target='_blank' href='https://coppermind.net/wiki/Words_of_Radiance/Epigraphs#The_Second_Letter'>Words of Radiance Part 4 epigraphs</a>."
+                                },
+                                {
+                                    "target": "au",
+                                    "type": "minor",
+                                    "description": "The <a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a> essay covers details about <a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a> and makes mentions of <a target='_blank' href='https://coppermind.net/wiki/Odium'>Odium</a>'s past."
+                                },
 				{
-					"label": "The Stormlight Archive",
-					"children": [
-						{
-							"id": "sa1",
-							"title": "The Way of Kings",
-							"title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Way_of_Kings'>The Way of Kings</a>",
-							"series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-							"publication": "August 2010",
-							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/309/#e10273'>Occurs after Mistborn Era 1 and Warbreaker but before Mistborn Era 2.</a>",
-							"sorting": {
-								"order": 2.41,
-								"publication": 2010.08,
-								"chronology": 7.01
-							},
-							"appearances": [
-								{
-									"id": "hoid",
-									"type": "appearance",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is 'Wit'."
-								},
-								{
-									"id": "ars",
-									"type": "appearance"
-								}
-							],
-							"categories": [
-								"stormlight",
-								"phase2",
-								"published",
-								"novel"
-							]
-						},
-						{
-							"id": "sa2",
-							"title": "Words of Radiance",
-							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Words_of_Radiance'>Words of Radiance</a>",
-							"series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-							"publication": "March 2014",
-							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/309/#e10273'>Occurs after Mistborn Era 1 and Warbreaker but before Mistborn Era 2.</a>",
-							"sorting": {
-								"order": 2.42,
-								"publication": 2014.03,
-								"chronology": 7.02
-							},
-							"appearances": [
-								{
-									"id": "hoid",
-									"type": "appearance",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is 'Wit'."
-								},
-								{
-									"id": "nazh",
-									"type": "appearance",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> is the <a target='_blank' href='https://coppermind.net/wiki/Ardent'>ardent</a> trying to get a sketch of <a target='_blank' href='https://coppermind.net/wiki/Bridge_Four'>Bridge Four</a>'s tattoo in <a target='_blank' href='https://coppermind.net/wiki/Summary:Words_of_Radiance#Chapter_31:_The_Stillness_Before'>Chapter 31</a>. Several drawings and sketches also include his annotations."
-								},
-								{
-									"id": "ars",
-									"type": "appearance"
-								}
-							],
-							"categories": [
-								"stormlight",
-								"phase2",
-								"published",
-								"novel"
-							],
-							"connections": [
-								{
-									"target": "jasnah",
-									"type": "major",
-									"description": "A deleted scene about <a target='_blank' href='https://coppermind.net/wiki/Jasnah_Kholin'>Jasnah</a> that contains some canonical elements."
-								},
-								{
-									"target": "traveler",
-									"type": "minor",
-									"description": "The man <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> speaks with is <a target='_blank' href='https://coppermind.net/wiki/Frost'>Frost</a>, who responded to <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> with similar opinions in the <a target='_blank' href='https://coppermind.net/wiki/Words_of_Radiance/Epigraphs#The_Second_Letter'>Words of Radiance Part 4 epigraphs</a>."
-								},
-								{
-									"target": "au",
-									"type": "minor",
-									"description": "The <a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a> essay covers details about <a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a> and makes mentions of <a target='_blank' href='https://coppermind.net/wiki/Odium'>Odium</a>'s past."
-								},
-								{
-									"target": "mb7",
-									"type": "minor",
-									"description": "WIP"
-								}
-							]
-						},
-						{
-							"id": "sa2.5",
-							"title": "Edgedancer",
-							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Edgedancer'>Edgedancer</a>",
-							"series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-							"au": "Included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
-							"padding": 12,
-							"publication": "November 2016",
-							"chronology": "Occurs after Words of Radiance and concurrently with the early events of Oathbringer.",
-							"sorting": {
-								"order": 2.43,
-								"publication": 2016.11,
-								"chronology": 7.025
-							},
-							"appearances": [
-								{
-									"id": "hoid",
-									"type": "mention",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is 'Ol' Whitehair', mentioned in <a target='_blank' href='https://coppermind.net/wiki/Summary:Edgedancer#Chapter_12'>Chapter 12</a>."
-								}
-							],
-							"categories": [
-								"stormlight",
-								"novella",
-								"phase2",
-								"published"
-							]
-						},
-						{
-							"id": "sa3",
-							"title": "Oathbringer",
-							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Oathbringer'>Oathbringer</a>",
-							"series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-							"publication": "November 2017",
-							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/309/#e10273'>Occurs after Mistborn Era 1 and Warbreaker but before Mistborn Era 2.</a>",
-							"sorting": {
-								"order": 2.44,
-								"publication": 2017.11,
-								"chronology": 7.03
-							},
-							"appearances": [
-								{
-									"id": "hoid",
-									"type": "appearance",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is 'Wit'."
-								},
-								{
-									"id": "nazh",
-									"type": "mention",
-									"description": "Several drawings and sketches include <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a>'s annotations. Most notably, the <a target='_blank' href='https://coppermind.net/wiki/Glyphs'>glyphs</a> page is entirely written by him."
-								},
-								{
-									"id": "ars",
-									"type": "appearance"
-								}
-							],
-							"categories": [
-								"stormlight",
-								"phase2",
-								"published",
-								"novel"
-							],
-							"connections": [
-								{
-									"target": "twokp",
-									"type": "minor",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/The_Way_of_Kings_Prime'>The Way of Kings Prime</a>, written in 2002, is the original draft of <a target='_blank' href='https://coppermind.net/wiki/The_Way_of_Kings'>The Way of Kings</a>. Only small excerpts were released prior to <a target='_blank' href='https://coppermind.net/wiki/The_Way_of_Kings'>Oathbringer</a> as Brandon felt it contained spoilers for certain ideas through that book. It was self-published as a Sanderson Curiosity in July 2020."
-								},
-								{
-									"target": "mb7",
-									"type": "minor",
-									"description": "WIP"
-								}
-							]
-						},
-						{
-							"id": "sa3.5",
-							"title": "Dawnshard",
-							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Dawnshard_(novella)'>Dawnshard</a>",
-							"series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-							"publication": "November 2020",
-							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/406/#e13986'>Between Oathbringer and Rhythm of War.</a>",
-							"padding": 12,
-							"sorting": {
-								"order": 2.45,
-								"publication": 2020.1105,
-								"chronology": 7.035
-							},
-							"categories": [
-								"stormlight",
-								"novella",
-								"published",
-								"phase2"
-							]
-						},
-						{
-							"id": "sa4",
-							"title": "Rhythm of War",
-							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Rhythm_of_War'>Rhythm of War</a>",
-							"series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-							"publication": "November 2020",
-							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/309/#e10273'>Occurs after Mistborn Era 1 and Warbreaker but before Mistborn Era 2.</a>",
-							"sorting": {
-								"order": 2.46,
-								"publication": 2020.1117,
-								"chronology": 7.04
-							},
-							"appearances": [
-								{
-									"id": "hoid",
-									"type": "appearance",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is 'Wit'."
-								},
-								{
-									"id": "nazh",
-									"type": "mention",
-									"description": "Several drawings and sketches include <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a>'s annotations. Most notably, the <a target='_blank' href='https://coppermind.net/wiki/Glyphs'>glyphs</a> page is entirely written by him."
-								},
-								{
-									"id": "ars",
-									"type": "appearance"
-								}
-							],
-							"categories": [
-								"stormlight",
-								"novel",
-								"phase2",
-								"published"
-							],
-							"connections": [
-								{
-									"target": "d1",
-									"type": "egg",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Microkinesis'>Microkinesis</a> referes to a type of magic from <a target='_blank' href='https://coppermind.net/wiki/Yolen'>Yolen</a> in <a target='_blank' href='https://coppermind.net/wiki/Dragonsteel'>Dragonsteel</a>."
-								},
-								{
-									"target": "mb2",
-									"type": "minor",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Ati'>Ati</a> speaks to <a target='_blank' href='https://coppermind.net/wiki/Vin'>Vin</a> and others with <a target='_blank' href='https://coppermind.net/wiki/Ruin'>Ruin's</a> <a target='_blank' href='https://coppermind.net/wiki/Rhythm#The_Pure_Tones'>Pure Tone</a>. The <a target='_blank' href='https://coppermind.net/wiki/Well_of_Ascension'>Well of Ascension</a> pulses with <a target='_blank' href='https://coppermind.net/wiki/Preservation'>Preservation's</a> <a target='_blank' href='https://coppermind.net/wiki/Rhythm#The_Pure_Tones'>Pure Tone</a>"
-								},
-								{
-									"target": "mb7",
-									"type": "significant",
-									"description": "WIP"
-								}
-							]
-						},
-						{
-							"id": "sa4.5",
-							"title": "Horneater (2023)",
-							"title2": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2019/'>Horneater</a>",
-							"series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-							"padding": 12,
-							"chronology": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>Fills in what happened with Rock after the events of Rhythm of War.</a>",
-							"sorting": {
-								"publication": 2023.11,
-								"chronology": 7.045
-							},
-							"categories": [
-								"stormlight",
-								"novella",
-								"plan",
-								"unpublished"
-							]
-						},
-						{
-							"id": "sa5",
-							"title": "Stormlight Archive 5 (2024)",
-							"title2": "Stormlight Archive 5",
-							"series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-							"publication": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>Fall 2023</a>",
-							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/309/#e10273'>Occurs after Mistborn Era 1 and Warbreaker but before Mistborn Era 2.</a>",
-							"sorting": {
-								"publication": 2023.11,
-								"chronology": 7.05
-							},
-							"categories": [
-								"stormlight",
-								"plan",
-								"forthcoming",
-								"novel"
-							]
-						},
-						{
-							"id": "lopen",
-							"title": "King Lopen the First",
-							"title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=king+lopen+the+first+of+alethkar'>King Lopen the First of Alethkar</a>",
-							"series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/31/#e1703'>Occurs concurrently with the final events of Words of Radiance.</a>",
-							"padding": 12,
-							"sorting": {
-								"chronology": 7.022
-							},
-							"categories": [
-								"stormlight",
-								"short",
-								"plan",
-								"unpublished"
-							]
-						},
-						{
-							"id": "tdatd",
-							"title": "The Dog and the Dragon",
-							"title2": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>The Dog and the Dragon picture book</a>",
-							"series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-							"padding": 12,
-							"categories": [
-								"stormlight",
-								"plan",
-								"unpublished",
-								"graphic"
-							]
-						},
-						{
-							"id": "tgwlu",
-							"title": "The Girl Who Looked Up",
-							"title2": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>The Girl Who Looked Up picture book</a>",
-							"series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-							"padding": 12,
-							"categories": [
-								"stormlight",
-								"plan",
-								"unpublished",
-								"graphic"
-							]
-						},
-						{
-							"id": "sa-art",
-							"title": "Stormlight Archive art book",
-							"title2": "<a target='_blank' href='https://wob.coppermind.net/events/396/#e13175'>Stormlight Archive art book</a>",
-							"series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-							"padding": 12,
-							"categories": [
-								"stormlight",
-								"plan",
-								"unpublished",
-								"graphic"
-							]
-						},
-						{
-							"id": "sa6",
-							"title": "Stormlight Archive 6",
-							"title2": "Stormlight Archive 6",
-							"series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/61/#e1300'>There's a roughly 15 year gap between Stormlight 5 and 6.</a> <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>Occurs after Mistborn Era 2 and before Mistborn Era 3.</a>",
-							"publication": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>2028 (best guess)</a>",
-							"sorting": {
-								"chronology": 9.06,
-								"publication": 2028
-							},
-							"categories": [
-								"stormlight",
-								"plan",
-								"unpublished",
-								"novel"
-							]
-						},
-						{
-							"id": "sa7",
-							"title": "Stormlight Archive 7",
-							"title2": "Stormlight Archive 7",
-							"series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/61/#e1300'>There's a roughly 15 year gap between Stormlight 5 and 6.</a> <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>Occurs after Mistborn Era 2 and before Mistborn Era 3.</a>",
-							"sorting": {
-								"chronology": 9.07
-							},
-							"categories": [
-								"stormlight",
-								"plan",
-								"unpublished",
-								"novel"
-							]
-						},
-						{
-							"id": "sa8",
-							"title": "Stormlight Archive 8",
-							"title2": "Stormlight Archive 8",
-							"series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/61/#e1300'>There's a roughly 15 year gap between Stormlight 5 and 6.</a> <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>Occurs after Mistborn Era 2 and before Mistborn Era 3.</a>",
-							"sorting": {
-								"chronology": 9.08
-							},
-							"categories": [
-								"stormlight",
-								"plan",
-								"unpublished",
-								"novel"
-							]
-						},
-						{
-							"id": "sa9",
-							"title": "Stormlight Archive 9",
-							"title2": "Stormlight Archive 9",
-							"series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/61/#e1300'>There's a roughly 15 year gap between Stormlight 5 and 6.</a> <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>Occurs after Mistborn Era 2 and before Mistborn Era 3.</a>",
-							"sorting": {
-								"chronology": 9.09
-							},
-							"categories": [
-								"stormlight",
-								"plan",
-								"unpublished",
-								"novel"
-							]
-						},
-						{
-							"id": "sa10",
-							"title": "Stormlight Archive 10",
-							"title2": "Stormlight Archive 10",
-							"series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/61/#e1300'>There's a roughly 15 year gap between Stormlight 5 and 6.</a> <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>Occurs after Mistborn Era 2 and before Mistborn Era 3.</a>",
-							"sorting": {
-								"chronology": 9.1
-							},
-							"categories": [
-								"stormlight",
-								"plan",
-								"unpublished",
-								"novel"
-							],
-							"connections": [
-								{
-									"target": "sotd2",
-									"type": "minor",
-									"description": "A <a target='_blank' href='https://coppermind.net/wiki/Knights_Radiant'>Knight Radiant</a> makes an appearance, weilding a 'Shardgun'."
-								}
-							]
-						}
-					]
-				},
-				{
-					"children": [
-						{
-							"id": "tsd",
-							"title": "The Silence Divine",
-							"title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Silence_Divine'>The Silence Divine</a>",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Ashyn'>Ashyn</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-							"link": "<a target='_blank' href='https://wob.coppermind.net/events/201/#e12303'>Excerpt on Arcanum.</a>",
-							"publication": "March 2014",
-							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/370/#e11901'>Occurs late in the Stormlight Archive era, around book 8.</a>",
-							"sorting": {
-								"publication": 2014.03,
-								"chronology": 9.081
-							},
-							"categories": [
-								"no-series",
-								"plan",
-								"unpublished",
-								"novella"
-							],
-							"connections": [
-								{
-									"target": "sa3",
-									"type": "minor",
-									"description": "The Silence Divine is set on <a target='_blank' href='https://coppermind.net/wiki/Ashyn'>Ashyn</a>, the world that the humans fled to <a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a> from."
-								}
-							]
-						}
-					]
+				    "target": "mb7",
+				    "type": "minor",
+				    "description": "WIP"
 				}
-			]
-		},
-		{
-			"label": "Taldain",
-			"color": "#d4c955",
-			"children": [
+                            ]
+                        },
+                        {
+                            "id": "sa2.5",
+                            "title": "Edgedancer",
+                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Edgedancer'>Edgedancer</a>",
+                            "series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+                            "au": "Included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
+                            "padding": 12,
+                            "publication": "November 2016",
+                            "chronology": "Occurs after Words of Radiance and concurrently with the early events of Oathbringer.",
+                            "sorting": {
+				"order": 2.43,
+                                "publication": 2016.11,
+                                "chronology": 7.025
+                            },
+                            "appearances": [
+                                {
+                                    "id": "hoid",
+                                    "type": "mention",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is 'Ol' Whitehair', mentioned in <a target='_blank' href='https://coppermind.net/wiki/Summary:Edgedancer#Chapter_12'>Chapter 12</a>."
+                                }
+                            ],
+                            "categories": [ "stormlight", "novella", "phase2", "published" ]
+                        },
+                        {
+                            "id": "sa3",
+                            "title": "Oathbringer",
+                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Oathbringer'>Oathbringer</a>",
+                            "series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+                            "publication": "November 2017",
+                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/309/#e10273'>Occurs after Mistborn Era 1 and Warbreaker but before Mistborn Era 2.</a>",
+                            "sorting": {
+				"order": 2.44,
+                                "publication": 2017.11,
+                                "chronology": 7.03
+                            },
+                            "appearances": [
+                                {
+                                    "id": "hoid",
+                                    "type": "appearance",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is 'Wit'."
+                                },
+                                {
+                                    "id": "nazh",
+                                    "type": "mention",
+                                    "description": "Several drawings and sketches include <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a>'s annotations. Most notably, the <a target='_blank' href='https://coppermind.net/wiki/Glyphs'>glyphs</a> page is entirely written by him."
+                                },
+                                {
+                                    "id": "ars",
+                                    "type": "appearance"
+                                }
+                            ],
+                            "categories": [ "stormlight", "phase2", "published", "novel" ],
+                            "connections": [
+                                {
+                                    "target": "twokp",
+                                    "type": "minor",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/The_Way_of_Kings_Prime'>The Way of Kings Prime</a>, written in 2002, is the original draft of <a target='_blank' href='https://coppermind.net/wiki/The_Way_of_Kings'>The Way of Kings</a>. Only small excerpts were released prior to <a target='_blank' href='https://coppermind.net/wiki/The_Way_of_Kings'>Oathbringer</a> as Brandon felt it contained spoilers for certain ideas through that book. It was self-published as a Sanderson Curiosity in July 2020."
+                                },
 				{
-					"label": "White Sand",
-					"children": [
-						{
-							"id": "ws1",
-							"title": "White Sand Volume 1",
-							"title2": "<a target='_blank' href='https://coppermind.net/wiki/White_Sand_Volume_1'>White Sand Volume 1</a>",
-							"series": "<a target='_blank' href='https://coppermind.net/wiki/White_Sand'>White Sand</a>",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Taldain_system'>Taldain system</a>",
-							"au": "Excerpt included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
-							"publication": "June 2016",
-							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/182/#e3878'>White Sand occurs prior to Elantris.</a>",
-							"sorting": {
-								"order": 2.11,
-								"publication": 2016.06,
-								"chronology": 2.1
-							},
-							"appearances": [
-								{
-									"id": "hoid",
-									"type": "appearance",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is the hooded man with a stringed instrument who first appears in <a target='_blank' href='https://coppermind.net/wiki/Ais'>Ais</a>'s first scene in the middle of <a target='_blank' href='https://coppermind.net/wiki/Summary:White_Sand_Volume_1#Chapter_4:_Divides'>Chapter 4</a>."
-								},
-								{
-									"id": "khriss",
-									"type": "appearance",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> is a main character."
-								}
-							],
-							"categories": [
-								"white-sand",
-								"phase2b",
-								"published",
-								"graphic"
-							],
-							"connections": [
-								{
-									"target": "mb1",
-									"type": "egg",
-									"description": "'Kenton Street' in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Well_of_Ascension#Chapter_17'>Chapter 17</a> (also mentioned in <a target='_blank' href='https://coppermind.net/wiki/The_Well_of_Ascension'>The Well of Ascension) is a reference to <a target='_blank' href='https://coppermind.net/wiki/Kenton'>Kenton</a>."
-								},
-								{
-									"target": "sa2",
-									"type": "egg",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Mraize'>Mraize</a>'s collection in <a target='_blank' href='https://coppermind.net/wiki/Summary:Words_of_Radiance#Chapter_43:_The_Ghostbloods'>Chapter 43</a> includes a vial of sand from <a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a>."
-								},
-								{
-									"target": "au",
-									"type": "minor",
-									"description": "The <a target='_blank' href='https://coppermind.net/wiki/Taldain_system'>Taldain system</a> essay discusses <a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a> and <a target='_blank' href='https://coppermind.net/wiki/Sand_mastery'>sand mastery</a>."
-								},
-								{
-									"target": "sa4",
-									"type": "minor",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a> is referenced in <a target='_blank' href='https://coppermind.net/wiki/Ialai'>Ialai's</a> notes."
-								},
-								{
-									"target": "mb7",
-									"type": "egg",
-									"description": "(WIP) Taldain is Autonomy's original planet. Aether manipulation drains the body's water supply like Sand mastery."
-								}
-							]
-						},
-						{
-							"id": "ws2",
-							"title": "White Sand Volume 2",
-							"title2": "<a target='_blank' href='https://coppermind.net/wiki/White_Sand_Volume 2'>White Sand Volume 2</a>",
-							"series": "<a target='_blank' href='https://coppermind.net/wiki/White_Sand'>White Sand</a>",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Taldain_system'>Taldain system</a>",
-							"publication": "February 2018",
-							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/182/#e3878'>White Sand occurs prior to Elantris.</a>",
-							"sorting": {
-								"order": 2.12,
-								"publication": 2018.02,
-								"chronology": 2.2
-							},
-							"appearances": [
-								{
-									"id": "hoid",
-									"type": "appearance",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is the hooded man with a stringed instrument."
-								},
-								{
-									"id": "khriss",
-									"type": "appearance",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> is a main character."
-								}
-							],
-							"categories": [
-								"white-sand",
-								"phase2b",
-								"published",
-								"graphic"
-							],
-							"connections": [
-								{
-									"target": "mb1",
-									"type": "minor",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Trell_(Taldain)'>Trell the foreman</a> is connected to <a target='_blank' href='https://coppermind.net/wiki/Trelagism'>Trelagism</a>."
-								},
-								{
-									"target": "mb4",
-									"type": "significant",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Trell_(Taldain)'>Trell the foreman</a> is connected to the god <a target='_blank' href='https://coppermind.net/wiki/Trellism'>Trell</a>."
-								},
-								{
-									"target": "sa3",
-									"type": "egg",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Wit</a> has a jar of black sand from <a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a> in <a target='_blank' href='https://coppermind.net/wiki/Summary:Oathbringer#Chapter_67:_Mishim'>Chapter 67</a>, which turns white after <a target='_blank' href='https://coppermind.net/wiki/Shallan'>Shallan</a> <a target='_blank' href='https://coppermind.net/wiki/Lightweaving'>Lightweaves</a>."
-								},
-								{
-									"target": "sa4",
-									"type": "minor",
-									"description": "Sand from <a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a> is used to identify and quantify <a target='_blank' href='https://coppermind.net/wiki/Investiture'>kinetic Investiture</a>, including explicit mention of the fauna which makes the sand special."
-								}
-							]
-						},
-						{
-							"id": "ws3",
-							"title": "White Sand Volume 3",
-							"title2": "<a target='_blank' href='https://coppermind.net/wiki/White_Sand_Volume_3'>White Sand Volume 3</a>",
-							"series": "<a target='_blank' href='https://coppermind.net/wiki/White_Sand'>White Sand</a>",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Taldain_system'>Taldain system</a>",
-							"publication": "October 2019",
-							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/182/#e3878'>White Sand occurs prior to Elantris.</a>",
-							"sorting": {
-								"order": 2.13,
-								"publication": 2019.1,
-								"chronology": 2.3
-							},
-							"appearances": [
-								{
-									"id": "hoid",
-									"type": "appearance",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is the hooded man with a stringed instrument who plays a song in the <a target='_blank' href='https://coppermind.net/wiki/Summary:White_Sand_Volume_3#Epilogue'>Epilogue</a>."
-								},
-								{
-									"id": "khriss",
-									"type": "appearance",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> is a main character."
-								}
-							],
-							"categories": [
-								"white-sand",
-								"phase2b",
-								"published",
-								"graphic"
-							],
-							"connections": [
-								{
-									"target": "sa1",
-									"type": "egg",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Baon'>Baon</a> appears in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Way_of_Kings#Interlude_I-1:_Ishikk'>Interlude I-1</a> as 'Blunt'."
-								}
-							]
-						}
-					]
-				},
-				{
-					"label": "The Arcanist",
-					"children": [
-						{
-							"id": "ta1",
-							"title": "The Arcanist Volume 1",
-							"title2": "The Arcanist Volume 1",
-							"series": "The Arcanist (citation needed)",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Taldain_system'>Taldain system</a>",
-							"chronology": "Described as a sequel, so presumably occurs shortly after White Sand.",
-							"sorting": {
-								"chronology": 2.5
-							},
-							"categories": [
-								"white-sand",
-								"plan",
-								"unpublished",
-								"graphic"
-							]
-						},
-						{
-							"id": "ta2",
-							"title": "The Arcanist Volume 2",
-							"title2": "The Arcanist Volume 2",
-							"series": "The Arcanist (citation needed)",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Taldain_system'>Taldain system</a>",
-							"chronology": "Described as a sequel, so presumably occurs shortly after White Sand.",
-							"sorting": {
-								"chronology": 2.6
-							},
-							"categories": [
-								"white-sand",
-								"plan",
-								"unpublished",
-								"graphic"
-							]
-						},
-						{
-							"id": "ta3",
-							"title": "The Arcanist Volume 3",
-							"title2": "The Arcanist Volume 3",
-							"series": "The Arcanist (citation needed)",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Taldain_system'>Taldain system</a>",
-							"chronology": "Described as a sequel, so presumably occurs shortly after White Sand.",
-							"sorting": {
-								"chronology": 2.7
-							},
-							"categories": [
-								"white-sand",
-								"plan",
-								"unpublished",
-								"graphic"
-							]
-						}
-					]
+				    "target": "mb7",
+				    "type": "minor",
+				    "description": "WIP"
 				}
-			]
-		},
-		{
-			"label": "Threnody",
-			"color": "#6633cc",
-			"children": [
+                            ]
+                        },
+                        {
+                            "id": "sa3.5",
+                            "title": "Dawnshard",
+                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Dawnshard_(novella)'>Dawnshard</a>",
+                            "series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+                            "publication": "November 2020",
+			    "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/406/#e13986'>Between Oathbringer and Rhythm of War.</a>",
+                            "padding": 12,
+                            "sorting": {
+				"order": 2.45,
+                                "publication": 2020.1105,
+                                "chronology": 7.035
+                            },
+                            "categories": [ "stormlight", "novella", "published", "phase2" ]
+                        },
+                        {
+                            "id": "sa4",
+                            "title": "Rhythm of War",
+                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Rhythm_of_War'>Rhythm of War</a>",
+                            "series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+                            "publication": "November 2020",
+                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/309/#e10273'>Occurs after Mistborn Era 1 and Warbreaker but before Mistborn Era 2.</a>",
+                            "sorting": {
+				"order": 2.46,
+                                "publication": 2020.1117,
+                                "chronology": 7.04
+                            },
+                            "appearances": [
+                                {
+                                    "id": "hoid",
+                                    "type": "appearance",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is 'Wit'."
+                                },
+                                {
+                                    "id": "nazh",
+                                    "type": "mention",
+                                    "description": "Several drawings and sketches include <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a>'s annotations. Most notably, the <a target='_blank' href='https://coppermind.net/wiki/Glyphs'>glyphs</a> page is entirely written by him."
+                                },
+                                {
+                                    "id": "ars",
+                                    "type": "appearance"
+                                }
+                            ],
+                            "categories": [ "stormlight", "novel", "phase2", "published" ],
+                            "connections": [
+                                {
+                                    "target": "d1",
+                                    "type": "egg",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Microkinesis'>Microkinesis</a> referes to a type of magic from <a target='_blank' href='https://coppermind.net/wiki/Yolen'>Yolen</a> in <a target='_blank' href='https://coppermind.net/wiki/Dragonsteel'>Dragonsteel</a>."
+                                },
+                                {
+                                    "target": "mb2",
+                                    "type": "minor",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Ati'>Ati</a> speaks to <a target='_blank' href='https://coppermind.net/wiki/Vin'>Vin</a> and others with <a target='_blank' href='https://coppermind.net/wiki/Ruin'>Ruin's</a> <a target='_blank' href='https://coppermind.net/wiki/Rhythm#The_Pure_Tones'>Pure Tone</a>. The <a target='_blank' href='https://coppermind.net/wiki/Well_of_Ascension'>Well of Ascension</a> pulses with <a target='_blank' href='https://coppermind.net/wiki/Preservation'>Preservation's</a> <a target='_blank' href='https://coppermind.net/wiki/Rhythm#The_Pure_Tones'>Pure Tone</a>"
+                                },
 				{
-					"children": [
-						{
-							"id": "sfs",
-							"title": "Shadows for Silence",
-							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Shadows_for_Silence_in_the_Forests_of_Hell'>Shadows for Silence in the Forests of Hell</a>",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Threnody'>Threnody</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Threnodite_system'>Threnodite system</a>",
-							"au": "Included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
-							"publication": "December 2013",
-							"chronology": "Occurs <a target='_blank' href='https://wob.coppermind.net/events/216/#e6445'>before Stormlight Archive</a> but <a target='_blank' href='https://wob.coppermind.net/events/309/#e10273'>after Warbreaker</a>.",
-							"sorting": {
-								"order": 1.5,
-								"publication": 2013.12,
-								"chronology": 6.1
-							},
-							"categories": [
-								"no-series",
-								"novella",
-								"phase1b",
-								"published"
-							],
-							"connections": [
-								{
-									"target": "sa2",
-									"type": "egg",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Mraize'>Mraize</a>'s collection in <a target='_blank' href='https://coppermind.net/wiki/Summary:Words_of_Radiance#Chapter_43:_The_Ghostbloods'>Chapter 43</a> includes a silver knife from <a target='_blank' href='https://coppermind.net/wiki/Threnody'>Threnody</a>."
-								},
-								{
-									"target": "sa3",
-									"type": "egg",
-									"description": "The silvery chain in <a target='_blank' href='https://coppermind.net/wiki/Celebrant'>Celebrant</a> is from <a target='_blank' href='https://coppermind.net/wiki/Threnody'>Threnody</a>."
-								},
-								{
-									"target": "msh",
-									"type": "minor",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Kelsier'>Kelsier</a> causes the <a target='_blank' href='https://coppermind.net/wiki/Ire'>Ire</a> to suspect <a target='_blank' href='https://coppermind.net/wiki/Shade'>Shades</a> from <a target='_blank' href='https://coppermind.net/wiki/Threnody'>Threnody</a> are nearby."
-								},
-								{
-									"target": "au",
-									"type": "minor",
-									"description": "The <a target='_blank' href='https://coppermind.net/wiki/Threnodite_system'>Threnodite system</a> essay discusses the history of <a target='_blank' href='https://coppermind.net/wiki/Threnody'>Threnody</a>."
-								},
-								{
-									"target": "sa4",
-									"type": "egg",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Raboniel'>Raboniel's</a> chain from 'the lands of the dead' is likely a <a target='_blank' href='https://coppermind.net/wiki/Silver'>silver</a> chain from <a target='_blank' href='https://coppermind.net/wiki/Threnody'>Threnody</a>."
-								}
-							]
-						}
-					]
-				},
-				{
-					"children": [
-						{
-							"id": "db",
-							"title": "The Dust Brigade",
-							"title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=the+dust+brigade'>The Dust Brigade</a>",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Threnody'>Threnody</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Threnodite_system'>Threnodite system</a>",
-							"categories": [
-								"no-series",
-								"plan",
-								"unpublished",
-								"novel"
-							]
-						}
-					]
+				    "target": "mb7",
+				    "type": "significant",
+				    "description": "WIP"
 				}
-			]
-		},
-		{
-			"label": "First of<br>the Sun",
-			"color": "#367485",
-			"children": [
+                            ]
+                        },
+                        {
+                            "id": "sa4.5",
+                            "title": "Horneater (2023)",
+                            "title2": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2019/'>Horneater</a>",
+                            "series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+                            "padding": 12,
+                            "chronology": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>Fills in what happened with Rock after the events of Rhythm of War.</a>",
+                            "sorting": {
+                                "publication": 2023.11,
+				"chronology": 7.045
+                            },
+                            "categories": [ "stormlight", "novella", "plan", "unpublished" ]
+                        },
+                        {
+                            "id": "sa5",
+                            "title": "Stormlight Archive 5 (2024)",
+                            "title2": "Stormlight Archive 5",
+                            "series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+                            "publication": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>Fall 2023</a>",
+                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/309/#e10273'>Occurs after Mistborn Era 1 and Warbreaker but before Mistborn Era 2.</a>",
+                            "sorting": {
+				"publication": 2023.11,
+                                "chronology": 7.05
+                            },
+                            "categories": [ "stormlight", "plan", "forthcoming", "novel" ]
+                        },
+                        {
+                            "id": "lopen",
+                            "title": "King Lopen the First",
+                            "title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=king+lopen+the+first+of+alethkar'>King Lopen the First of Alethkar</a>",
+                            "series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/31/#e1703'>Occurs concurrently with the final events of Words of Radiance.</a>",
+                            "padding": 12,
+                            "sorting": {
+                                "chronology": 7.022
+                            },
+                            "categories": [ "stormlight", "short", "plan", "unpublished" ]
+                        },
+                        {
+                            "id": "tdatd",
+                            "title": "The Dog and the Dragon",
+                            "title2": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>The Dog and the Dragon picture book</a>",
+                            "series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+                            "padding": 12,
+                            "categories": [ "stormlight", "plan", "unpublished", "graphic" ]
+                        },
+                        {
+                            "id": "tgwlu",
+                            "title": "The Girl Who Looked Up",
+                            "title2": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>The Girl Who Looked Up picture book</a>",
+                            "series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+                            "padding": 12,
+                            "categories": [ "stormlight", "plan", "unpublished", "graphic" ]
+                        },
+                        {
+                            "id": "sa-art",
+                            "title": "Stormlight Archive art book",
+                            "title2": "<a target='_blank' href='https://wob.coppermind.net/events/396/#e13175'>Stormlight Archive art book</a>",
+                            "series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+                            "padding": 12,
+                            "categories": [ "stormlight", "plan", "unpublished", "graphic" ]
+                        },
+                        {
+                            "id": "sa6",
+                            "title": "Stormlight Archive 6",
+                            "title2": "Stormlight Archive 6",
+                            "series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/61/#e1300'>There's a roughly 15 year gap between Stormlight 5 and 6.</a> <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>Occurs after Mistborn Era 2 and before Mistborn Era 3.</a>",
+                            "publication": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>2028 (best guess)</a>",
+                            "sorting": {
+                                "chronology": 9.06,
+				"publication": 2028
+                            },
+                            "categories": [ "stormlight", "plan", "unpublished", "novel" ]
+                        },
+                        {
+                            "id": "sa7",
+                            "title": "Stormlight Archive 7",
+                            "title2": "Stormlight Archive 7",
+                            "series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/61/#e1300'>There's a roughly 15 year gap between Stormlight 5 and 6.</a> <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>Occurs after Mistborn Era 2 and before Mistborn Era 3.</a>",
+                            "sorting": {
+                                "chronology": 9.07
+                            },
+                            "categories": [ "stormlight", "plan", "unpublished", "novel" ]
+                        },
+                        {
+                            "id": "sa8",
+                            "title": "Stormlight Archive 8",
+                            "title2": "Stormlight Archive 8",
+                            "series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/61/#e1300'>There's a roughly 15 year gap between Stormlight 5 and 6.</a> <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>Occurs after Mistborn Era 2 and before Mistborn Era 3.</a>",
+                            "sorting": {
+                                "chronology": 9.08
+                            },
+                            "categories": [ "stormlight", "plan", "unpublished", "novel" ]
+                        },
+                        {
+                            "id": "sa9",
+                            "title": "Stormlight Archive 9",
+                            "title2": "Stormlight Archive 9",
+                            "series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/61/#e1300'>There's a roughly 15 year gap between Stormlight 5 and 6.</a> <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>Occurs after Mistborn Era 2 and before Mistborn Era 3.</a>",
+                            "sorting": {
+                                "chronology": 9.09
+                            },
+                            "categories": [ "stormlight", "plan", "unpublished", "novel" ]
+                        },
+                        {
+                            "id": "sa10",
+                            "title": "Stormlight Archive 10",
+                            "title2": "Stormlight Archive 10",
+                            "series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/61/#e1300'>There's a roughly 15 year gap between Stormlight 5 and 6.</a> <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>Occurs after Mistborn Era 2 and before Mistborn Era 3.</a>",
+                            "sorting": {
+                                "chronology": 9.10
+                            },
+                            "categories": [ "stormlight", "plan", "unpublished", "novel" ],
+                            "connections": [
+                                {
+                                    "target": "sotd2",
+                                    "type": "minor",
+                                    "description": "A <a target='_blank' href='https://coppermind.net/wiki/Knights_Radiant'>Knight Radiant</a> makes an appearance, weilding a 'Shardgun'."
+                                }
+                            ]
+                        }
+                    ]
+                },
 				{
 					"children": [
-						{
-							"id": "sotd",
-							"title": "Sixth of the Dusk",
-							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Sixth_of_the_Dusk'>Sixth of the Dusk</a>",
-							"series": "Sixth of<br>the Dusk",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/First_of_the_Sun'>First of the Sun</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Drominad_system'>Drominad system</a>",
-							"au": "Included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
-							"publication": "June 2014",
-							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/60/#e6664'>Shortly before Mistborn Era 4.</a>",
-							"sorting": {
-								"order": 1.6,
-								"publication": 2014.06,
-								"chronology": 13.0
-							},
-							"categories": [
-								"no-series",
-								"novella",
-								"phase1b",
-								"published"
-							],
-							"connections": [
-								{
-									"target": "sa3",
-									"type": "minor",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Mraize'>Mraize</a>'s chicken, mentioned in <a target='_blank' href='https://coppermind.net/wiki/Summary:Oathbringer#Chapter_22:_The_Darkness_Within'>Chapter 22</a>, is an <a target='_blank' href='https://coppermind.net/wiki/Aviar'>Aviar</a>. <a target='_blank' href='https://coppermind.net/wiki/Patji'>Patji</a> is referenced obliquely in <a target='_blank' href='https://coppermind.net/wiki/Autonomy'>Autonomy</a>'s <a target='_blank' href='https://coppermind.net/wiki/Letters#Second_Oathbringer_Letter'>letter</a> to <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> in the <a target='_blank' href='https://coppermind.net/wiki/Oathbringer/Epigraphs#Letters'>Part 2 epigraphs</a>."
-								},
-								{
-									"target": "au",
-									"type": "minor",
-									"description": "The <a target='_blank' href='https://coppermind.net/wiki/Drominad_system'>Drominad system</a> essay discusses <a target='_blank' href='https://coppermind.net/wiki/First_of_the_Sun'>First of the Sun</a> and its magic."
-								},
-								{
-									"target": "sa4",
-									"type": "minor",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Gereh'>Gereh</a> has an <a target='_blank' href='https://coppermind.net/wiki/Aviar'>Aviar</a>, which <a target='_blank' href='https://coppermind.net/wiki/Lift'>Lift</a> comes into possession of."
-								}
-							]
-						},
-						{
-							"id": "sotd2",
-							"title": "Sixth of the Dusk sequel",
-							"title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=sixth+of+the+dusk+sequel'>Sixth of the Dusk sequel</a>",
-							"series": "Sixth of<br>the Dusk",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/First_of_the_Sun'>First of the Sun</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Drominad_system'>Drominad system</a>",
-							"chronology": "Five years after Sixth of the Dusk.",
-							"sorting": {
-								"chronology": 13.02
-							},
-							"link": "<a target='_blank' href='https://wob.coppermind.net/events/448/#e14408'>Excerpt on Arcanum.</a> (some may consider to be spoilers)",
-							"categories": [
-								"no-series",
-								"novella",
-								"plan",
-								"unpublished"
-							]
-						}
-					]
-				},
-				{
-					"children": [
-						{
-							"id": "kingmaker",
-							"title": "Kingmaker",
-							"title2": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>Kingmaker</a>",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/First_of_the_Sun'>First of the Sun</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Drominad_system'>Drominad system</a>",
-							"link": "<a target='_blank' href='https://wob.coppermind.net/events/479/#e15153'>Reading on Arcanum.</a>",
-							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/479/#e15153'>The reading suggests a setting not long after Sixth of the Dusk.</a>",
-							"sorting": {
-								"chronology": 13.01
-							},
-							"categories": [
-								"no-series",
-								"novel",
-								"plan",
-								"unpublished"
-							]
-						}
-					]
-				}
-			]
-		},
-		{
-			"label": "Yolen",
-			"color": "#d98a41",
-			"children": [
-				{
-					"label": "Dragonsteel",
-					"children": [
-						{
-							"id": "d1",
-							"title": "Dragonsteel 1",
-							"title2": "Dragonsteel 1",
-							"series": "<a target='_blank' href='https://coppermind.net/wiki/Dragonsteel'>Dragonsteel</a>",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Yolen'>Yolen</a>",
-							"system": "Yolish system",
-							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/103/#e1024'>Dragonsteel is the first series in the cosmere storyline.</a>",
-							"sorting": {
-								"chronology": 1.1
-							},
-							"categories": [
-								"dragonsteel",
-								"plan",
-								"unpublished",
-								"novel"
-							],
-							"connections": [
-								{
-									"target": "mb7",
-									"type": "egg",
-									"description": "(WIP) A Sho Del is described in the epilogue."
-								}
-							]
-						},
-						{
-							"id": "d2",
-							"title": "Dragonsteel 2",
-							"title2": "Dragonsteel 2",
-							"series": "<a target='_blank' href='https://coppermind.net/wiki/Dragonsteel'>Dragonsteel</a>",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Yolen'>Yolen</a>",
-							"system": "Yolish system",
-							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/103/#e1024'>Dragonsteel is the first series in the cosmere storyline.</a>",
-							"sorting": {
-								"chronology": 1.2
-							},
-							"categories": [
-								"dragonsteel",
-								"plan",
-								"unpublished",
-								"novel"
-							]
-						},
-						{
-							"id": "d3",
-							"title": "Dragonsteel 3",
-							"title2": "Dragonsteel 3",
-							"series": "<a target='_blank' href='https://coppermind.net/wiki/Dragonsteel'>Dragonsteel</a>",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Yolen'>Yolen</a>",
-							"system": "Yolish system",
-							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/103/#e1024'>Dragonsteel is the first series in the cosmere storyline.</a>",
-							"sorting": {
-								"chronology": 1.3
-							},
-							"categories": [
-								"dragonsteel",
-								"plan",
-								"unpublished",
-								"novel"
-							]
-						}
-					]
-				}
-			]
-		},
-		{
-			"label": "Other",
-			"color": "#a0a0a0",
-			"children": [
-				{
-					"label": "Aether<br>Series",
-					"color": "#e3a1e3",
-					"children": [
-						{
-							"id": "aether1",
-							"title": "Aether Book 1",
-							"title2": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2019/'>Aether Book 1</a>",
-							"world": "Unknown",
-							"system": "Unknown",
-							"categories": [
-								"aether",
-								"novel",
-								"plan",
-								"unpublished"
-							]
-						},
-						{
-							"id": "aether2",
-							"title": "Aether Book 2",
-							"title2": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2019/'>Aether Book 2</a>",
-							"world": "Unknown",
-							"system": "Unknown",
-							"categories": [
-								"aether",
-								"novel",
-								"plan",
-								"unpublished"
-							]
-						},
-						{
-							"id": "aether3",
-							"title": "Aether Book 3",
-							"title2": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2019/'>Aether Book 3</a>",
-							"world": "Unknown",
-							"system": "Unknown",
-							"categories": [
-								"aether",
-								"novel",
-								"plan",
-								"unpublished"
-							]
-						}
-					]
-				},
-				{
-					"children": [
-						{
-							"id": "secret1",
-							"title": "Secret Project 1 (2023)",
-							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Secret_Project_One'>Secret Project 1</a>",
-							"world": "Spoiler",
-							"system": "Spoiler",
-							"publication": "January 2023",
-							"sorting": {
-								"publication": 2023.01
-							},
-							"link": "Chapters 1-5 available on <a target='_blank' href='brandonsanderson.com/first-look-at-secret-project-1'>Brandon's website</a> and <a target='_blank' href='https://youtu.be/bBUVXcIE0E0'>YouTube</a>. (some may consider to be spoilers)",
-							"categories": [
-								"no-series",
-								"novel",
-								"plan",
-								"forthcoming"
-							]
-						}
-					]
-				},
-				{
-					"children": [
-						{
-							"id": "secret3",
-							"title": "Secret Project 3 (2023)",
-							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Secret_Project_Three'>Secret Project 3</a>",
-							"world": "Spoiler",
-							"system": "Spoiler",
-							"publication": "July 2023",
-							"sorting": {
-								"publication": 2023.07
-							},
-							"link": "Chapters 1-7 available on <a target='_blank' href='brandonsanderson.com/first-look-at-secret-project-3'>Brandon's website</a> and <a target='_blank' href='https://youtu.be/cFGDcvtRdz0'>YouTube</a>. (some may consider to be spoilers)",
-							"categories": [
-								"no-series",
-								"novel",
-								"plan",
-								"forthcoming"
-							]
-						}
-					]
-				},
-				{
-					"children": [
-						{
-							"id": "secret4",
-							"title": "Secret Project 4 (2023)",
-							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Secret_Project_Four'>Secret Project 4</a>",
-							"world": "Spoiler",
-							"system": "Spoiler",
-							"publication": "October 2023",
-							"sorting": {
-								"publication": 2023.1
-							},
-							"categories": [
-								"no-series",
-								"novel",
-								"plan",
-								"forthcoming"
-							]
-						}
-					]
-				},
-				{
-					"children": [
-						{
-							"id": "silverlight",
-							"title": "Silverlight novella",
-							"title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=silverlight+novella'>Silverlight novella</a>",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Cognitive_Realm'>Cognitive Realm</a>",
-							"system": "N/A",
-							"categories": [
-								"no-series",
-								"novella",
-								"plan",
-								"unpublished"
-							]
-						}
-					]
-				},
-				{
-					"children": [
-						{
-							"id": "kite",
-							"title": "Magic Kites YA story",
-							"title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=kite+magic'>Kite-based magic story</a>",
-							"world": "Unknown",
-							"system": "Unknown",
-							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/379/#e12466'>Planned to take place between Mistborn Era 3 and 4.</a>",
-							"sorting": {
-								"chronology": 11.0
-							},
-							"categories": [
-								"no-series",
-								"novella",
-								"plan",
-								"unpublished"
-							]
-						}
-					]
-				},
-				{
-					"children": [
-						{
-							"id": "au",
-							"title": "Arcanum Unbounded (essays)",
-							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded (essays)</a>",
-							"world": "N/A",
-							"system": "N/A",
-							"au": "Included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
-							"publication": "November 2016",
-							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/36/#e1491'>The essays were written before the events of Sixth of the Dusk.</a> They could potentially be as early as Mistborn Era 3.",
-							"sorting": {
-								"order": 2.3,
-								"publication": 2016.11,
-								"chronology": 12.0
-							},
-							"appearances": [
-								{
-									"id": "khriss",
-									"type": "mention",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> is the author of the essays."
-								}
-							],
-							"categories": [
-								"no-series",
-								"short",
-								"phase2",
-								"published"
-							],
-							"connections": [
-								{
-									"target": "sa4",
-									"type": "minor",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Devotion'>Devotion</a> and <a target='_blank' href='https://coppermind.net/wiki/Dominion'>Dominion</a> are referenced in the <a target='_blank' href='https://coppermind.net/wiki/Rhythm_of_War/Epigraphs'>Chapter 26 Epigraph</a>. <a target='_blank' href='https://coppermind.net/wiki/Ambition'>Ambition's</a> struggle with <a target='_blank' href='https://coppermind.net/wiki/Odium'>Odium</a> is referenced in the <a target='_blank' href='https://coppermind.net/wiki/Rhythm_of_War/Epigraphs'>Chapter 27 Epigraph</a>."
-								},
-								{
-									"target": "mb7",
-									"type": "minor",
-									"description": "WIP"
-								}
-							]
-						}
-					]
-				}
-			]
-		},
-		{
-			"label": "Mixed",
-			"color": "#a0a0a0",
-			"children": [
-				{
-					"children": [
-						{
-							"id": "wsp",
-							"title": "White Sand (prose)",
-							"title2": "<a target='_blank' href='https://coppermind.net/wiki/White_Sand_(prose)'>White Sand (prose)</a>",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Taldain_system'>Taldain system</a>",
-							"au": "Excerpt included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded.</a>.",
-							"link": "<a target='_blank' href='https://brandonsanderson.com/newsletter-signup/'>Link to full text found in Brandon's newsletter.</a>",
-							"publication": "June 2009 (upon request)",
-							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/182/#e3878'>White Sand occurs prior to Elantris.</a>",
-							"sorting": {
-								"order": 2.14,
-								"publication": 2009.06,
-								"chronology": 2.0
-							},
-							"appearances": [
-								{
-									"id": "khriss",
-									"type": "appearance",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> is a main character."
-								}
-							],
-							"categories": [
-								"white-sand",
-								"novel",
-								"apocryphal",
-								"noncanon"
-							],
-							"connections": [
-								{
-									"target": "ws1",
-									"type": "minor",
-									"description": "The <a target='_blank' href='https://coppermind.net/wiki/White_Sand'>White Sand</a> graphic novels are based on the prose version."
-								}
-							]
-						},
-						{
-							"id": "aon",
-							"title": "Aether of Night",
-							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Aether_of_Night'>Aether of Night</a>",
-							"world": "Unknown",
-							"system": "Unknown",
-							"link": "<a target='_blank' href='https://www.17thshard.com/forum/topic/60219-aether-of-night-manuscript-requests/'>Full text available from the 17th Shard.</a>",
-							"publication": "June 2009 (upon request)",
-							"sorting": {
-								"order": 2.92,
-								"publication": 2009.06
-							},
-							"categories": [
-								"no-series",
-								"apocryphal",
-								"noncanon",
-								"novel"
-							],
-							"connections": [
-								{
-									"target": "sa2",
-									"type": "egg",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Mraize'>Mraize</a>'s collection in <a target='_blank' href='https://coppermind.net/wiki/Summary:Words_of_Radiance#Chapter_43:_The_Ghostbloods'>Chapter 43</a> includes pink <a target='_blank' href='https://coppermind.net/wiki/Aether'>aether</a>."
-								},
-								{
-									"target": "sa3",
-									"type": "egg",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Mraize'>Mraize</a> mentions his suit was stained with <a target='_blank' href='https://coppermind.net/wiki/Aether'>aether</a>."
-								},
-								{
-									"target": "sa4",
-									"type": "egg",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Foil'>Foil</a> is said to be seeking 'control over the <a target='_blank' href='https://coppermind.net/wiki/Aether'>aethers</a>'."
-								},
-								{
-									"target": "mb7",
-									"type": "minor",
-									"description": "(WIP) TwinSoul can manipulates the Aethers."
-								}
-							]
-						},
-						{
-							"id": "imperial-fool",
-							"title": "Imperial Fool",
-							"title2": "Imperial Fool",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Sel'>Sel</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Selish_system'>Selish system</a>",
-							"link": "<a target='_blank' href='https://brandonsanderson.com/the-emperors-soul-deleted-prologue-imperial-fool'>Full text on Brandon's website.</a>",
-							"publication": "November 2012",
-							"chronology": "Concerns events shortly before the events of The Emperor's Soul.",
-							"sorting": {
-								"order": 1.41,
-								"publication": 2012.11,
-								"chronology": 3.4
-							},
-							"appearances": [
-								{
-									"id": "hoid",
-									"type": "appearance",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is the 'Imperial Fool'."
-								}
-							],
-							"categories": [
-								"no-series",
-								"short",
-								"apocryphal",
-								"noncanon"
-							]
-						},
-						{
-							"id": "twokp",
-							"title": "The Way of Kings Prime",
-							"title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Way_of_Kings_Prime'>The Way of Kings Prime</a>",
-							"series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-							"link": "<a target='_blank' href='https://www.brandonsanderson.com/the-way-of-kings-prime/'>Full novel on Brandon's website.</a>",
-							"publication": "July 2020",
-							"sorting": {
-								"order": 2.91,
-								"publication": 2020.07
-							},
-							"categories": [
-								"stormlight",
-								"novel",
-								"apocryphal",
-								"noncanon"
-							]
-						},
-						{
-							"id": "jasnah",
-							"title": "Jasnah deleted scene",
-							"title2": "Jasnah deleted scene",
-							"series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
-							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-							"link": "<a target='_blank' href='https://www.tor.com/2014/08/06/stormlight-archive-scene-after-words-of-radiance'>Full text on Tor.com.</a>",
-							"publication": "August 2014",
-							"chronology": "Occurs during the early events of Words of Radiance.",
-							"sorting": {
-								"order": 2.421,
-								"publication": 2014.08,
-								"chronology": 7.021
-							},
-							"categories": [
-								"stormlight",
-								"short",
-								"apocryphal",
-								"noncanon"
-							]
-						},
-						{
-							"id": "traveler",
-							"title": "The Traveler",
-							"title2": "The Traveler",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/Yolen'>Yolen</a>",
-							"system": "Yolish system",
-							"link": "<a target='_blank' href='https://wob.coppermind.net/events/332/#e9518'>Full text on Arcanum.</a>",
-							"publication": "April 2018",
-							"chronology": "Occurs shortly after Mistborn Era 1.",
-							"sorting": {
-								"order": 2.26,
-								"publication": 2018.04,
-								"chronology": 4.5
-							},
-							"appearances": [
-								{
-									"id": "hoid",
-									"type": "appearance",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is 'the Traveler'."
-								}
-							],
-							"categories": [
-								"no-series",
-								"short",
-								"apocryphal",
-								"noncanon"
-							]
-						}
-					]
-				}
-			]
+                        {
+                            "id": "tsd",
+                            "title": "The Silence Divine",
+                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Silence_Divine'>The Silence Divine</a>",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Ashyn'>Ashyn</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+                            "link": "<a target='_blank' href='https://wob.coppermind.net/events/201/#e12303'>Excerpt on Arcanum.</a>",
+                            "publication": "March 2014",
+                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/370/#e11901'>Occurs late in the Stormlight Archive era, around book 8.</a>",
+                            "sorting": {
+                                "publication": 2014.03,
+                                "chronology": 9.081
+                            },
+                            "categories": [ "no-series", "plan", "unpublished", "novella" ],
+                            "connections": [
+                                {
+                                    "target": "sa3",
+                                    "type": "minor",
+                                    "description": "The Silence Divine is set on <a target='_blank' href='https://coppermind.net/wiki/Ashyn'>Ashyn</a>, the world that the humans fled to <a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a> from."
+                                }
+                            ]
+                        }
+		    ]
 		}
-	]
+            ]
+        },
+        {
+            "label": "Taldain",
+            "color": "#d4c955",
+            "children": [
+                {
+                    "label": "White Sand",
+                    "children": [
+                        {
+                            "id": "ws1",
+                            "title": "White Sand Volume 1",
+                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/White_Sand_Volume_1'>White Sand Volume 1</a>",
+                            "series": "<a target='_blank' href='https://coppermind.net/wiki/White_Sand'>White Sand</a>",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Taldain_system'>Taldain system</a>",
+                            "au": "Excerpt included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
+                            "publication": "June 2016",
+                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/182/#e3878'>White Sand occurs prior to Elantris.</a>",
+                            "sorting": {
+				"order": 2.11,
+                                "publication": 2016.06,
+                                "chronology": 2.1
+                            },
+                            "appearances": [
+                                {
+                                    "id": "hoid",
+                                    "type": "appearance",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is the hooded man with a stringed instrument who first appears in <a target='_blank' href='https://coppermind.net/wiki/Ais'>Ais</a>'s first scene in the middle of <a target='_blank' href='https://coppermind.net/wiki/Summary:White_Sand_Volume_1#Chapter_4:_Divides'>Chapter 4</a>."
+                                },
+                                {
+                                    "id": "khriss",
+                                    "type": "appearance",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> is a main character."
+                                }
+                            ],
+                            "categories": [ "white-sand", "phase2b", "published", "graphic" ],
+                            "connections": [
+                                {
+                                    "target": "mb1",
+                                    "type": "egg",
+                                    "description": "'Kenton Street' in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Well_of_Ascension#Chapter_17'>Chapter 17</a> (also mentioned in <a target='_blank' href='https://coppermind.net/wiki/The_Well_of_Ascension'>The Well of Ascension) is a reference to <a target='_blank' href='https://coppermind.net/wiki/Kenton'>Kenton</a>."
+                                },
+                                {
+                                    "target": "sa2",
+                                    "type": "egg",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Mraize'>Mraize</a>'s collection in <a target='_blank' href='https://coppermind.net/wiki/Summary:Words_of_Radiance#Chapter_43:_The_Ghostbloods'>Chapter 43</a> includes a vial of sand from <a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a>."
+                                },
+                                {
+                                    "target": "au",
+                                    "type": "minor",
+                                    "description": "The <a target='_blank' href='https://coppermind.net/wiki/Taldain_system'>Taldain system</a> essay discusses <a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a> and <a target='_blank' href='https://coppermind.net/wiki/Sand_mastery'>sand mastery</a>."
+                                },
+                                {
+                                    "target": "sa4",
+                                    "type": "minor",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a> is referenced in <a target='_blank' href='https://coppermind.net/wiki/Ialai'>Ialai's</a> notes."
+                                },
+				{
+				    "target": "mb7",
+				    "type": "minor",
+				    "description": "WIP"
+				}
+                            ]
+                        },
+                        {
+                            "id": "ws2",
+                            "title": "White Sand Volume 2",
+                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/White_Sand_Volume 2'>White Sand Volume 2</a>",
+                            "series": "<a target='_blank' href='https://coppermind.net/wiki/White_Sand'>White Sand</a>",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Taldain_system'>Taldain system</a>",
+                            "publication": "February 2018",
+                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/182/#e3878'>White Sand occurs prior to Elantris.</a>",
+                            "sorting": {
+				"order": 2.12,
+                                "publication": 2018.02,
+                                "chronology": 2.2
+                            },
+                            "appearances": [
+                                {
+                                    "id": "hoid",
+                                    "type": "appearance",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is the hooded man with a stringed instrument."
+                                },
+                                {
+                                    "id": "khriss",
+                                    "type": "appearance",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> is a main character."
+                                }
+                            ],
+                            "categories": [ "white-sand", "phase2b", "published", "graphic" ],
+                            "connections": [
+                                {
+                                    "target": "mb1",
+                                    "type": "minor",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Trell_(Taldain)'>Trell the foreman</a> is connected to <a target='_blank' href='https://coppermind.net/wiki/Trelagism'>Trelagism</a>."
+                                },
+                                {
+                                    "target": "mb4",
+                                    "type": "significant",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Trell_(Taldain)'>Trell the foreman</a> is connected to the god <a target='_blank' href='https://coppermind.net/wiki/Trellism'>Trell</a>."
+                                },
+                                {
+                                    "target": "sa3",
+                                    "type": "egg",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Wit</a> has a jar of black sand from <a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a> in <a target='_blank' href='https://coppermind.net/wiki/Summary:Oathbringer#Chapter_67:_Mishim'>Chapter 67</a>, which turns white after <a target='_blank' href='https://coppermind.net/wiki/Shallan'>Shallan</a> <a target='_blank' href='https://coppermind.net/wiki/Lightweaving'>Lightweaves</a>."
+                                },
+                                {
+                                    "target": "sa4",
+                                    "type": "minor",
+                                    "description": "Sand from <a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a> is used to identify and quantify <a target='_blank' href='https://coppermind.net/wiki/Investiture'>kinetic Investiture</a>, including explicit mention of the fauna which makes the sand special."
+                                }
+                            ]
+                        },
+                        {
+                            "id": "ws3",
+                            "title": "White Sand Volume 3",
+                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/White_Sand_Volume_3'>White Sand Volume 3</a>",
+                            "series": "<a target='_blank' href='https://coppermind.net/wiki/White_Sand'>White Sand</a>",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Taldain_system'>Taldain system</a>",
+                            "publication": "October 2019",
+                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/182/#e3878'>White Sand occurs prior to Elantris.</a>",
+                            "sorting": {
+				"order": 2.13,
+                                "publication": 2019.10,
+                                "chronology": 2.3
+                            },
+                            "appearances": [
+                                {
+                                    "id": "hoid",
+                                    "type": "appearance",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is the hooded man with a stringed instrument who plays a song in the <a target='_blank' href='https://coppermind.net/wiki/Summary:White_Sand_Volume_3#Epilogue'>Epilogue</a>."
+                                },
+                                {
+                                    "id": "khriss",
+                                    "type": "appearance",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> is a main character."
+                                }
+                            ],
+                            "categories": [ "white-sand", "phase2b", "published", "graphic" ],
+                            "connections": [
+                                {
+                                    "target": "sa1",
+                                    "type": "egg",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Baon'>Baon</a> appears in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Way_of_Kings#Interlude_I-1:_Ishikk'>Interlude I-1</a> as 'Blunt'."
+                                }
+                            ]
+                        }
+                    ]
+                },
+		{
+                    "label": "The Arcanist",
+                    "children": [
+                        {
+                            "id": "ta1",
+                            "title": "The Arcanist Volume 1",
+                            "title2": "The Arcanist Volume 1",
+                            "series": "The Arcanist (citation needed)",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Taldain_system'>Taldain system</a>",
+                            "chronology": "Described as a sequel, so presumably occurs shortly after White Sand.",
+                            "sorting": {
+                                "chronology": 2.5
+                            },
+                            "categories": [ "white-sand", "plan", "unpublished", "graphic" ]
+                        },
+                        {
+                            "id": "ta2",
+                            "title": "The Arcanist Volume 2",
+                            "title2": "The Arcanist Volume 2",
+                            "series": "The Arcanist (citation needed)",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Taldain_system'>Taldain system</a>",
+                            "chronology": "Described as a sequel, so presumably occurs shortly after White Sand.",
+                            "sorting": {
+                                "chronology": 2.6
+                            },
+                            "categories": [ "white-sand", "plan", "unpublished", "graphic" ]
+                        },
+                        {
+                            "id": "ta3",
+                            "title": "The Arcanist Volume 3",
+                            "title2": "The Arcanist Volume 3",
+                            "series": "The Arcanist (citation needed)",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Taldain_system'>Taldain system</a>",
+                            "chronology": "Described as a sequel, so presumably occurs shortly after White Sand.",
+                            "sorting": {
+                                "chronology": 2.7
+                            },
+                            "categories": [ "white-sand", "plan", "unpublished", "graphic" ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "label": "Threnody",
+            "color": "#6633cc",
+            "children": [
+                {
+                    "children": [
+                        {
+                            "id": "sfs",
+                            "title": "Shadows for Silence",
+                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Shadows_for_Silence_in_the_Forests_of_Hell'>Shadows for Silence in the Forests of Hell</a>",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Threnody'>Threnody</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Threnodite_system'>Threnodite system</a>",
+                            "au": "Included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
+                            "publication": "December 2013",
+                            "chronology": "Occurs <a target='_blank' href='https://wob.coppermind.net/events/216/#e6445'>before Stormlight Archive</a> but <a target='_blank' href='https://wob.coppermind.net/events/309/#e10273'>after Warbreaker</a>.",
+                            "sorting": {
+				"order": 1.5,
+                                "publication": 2013.12,
+                                "chronology": 6.1
+                            },
+                            "categories": [ "no-series", "novella", "phase1b", "published" ],
+                            "connections": [
+                                {
+                                    "target": "sa2",
+                                    "type": "egg",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Mraize'>Mraize</a>'s collection in <a target='_blank' href='https://coppermind.net/wiki/Summary:Words_of_Radiance#Chapter_43:_The_Ghostbloods'>Chapter 43</a> includes a silver knife from <a target='_blank' href='https://coppermind.net/wiki/Threnody'>Threnody</a>."
+                                },
+                                {
+                                    "target": "sa3",
+                                    "type": "egg",
+                                    "description": "The silvery chain in <a target='_blank' href='https://coppermind.net/wiki/Celebrant'>Celebrant</a> is from <a target='_blank' href='https://coppermind.net/wiki/Threnody'>Threnody</a>."
+                                },
+                                {
+                                    "target": "msh",
+                                    "type": "minor",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Kelsier'>Kelsier</a> causes the <a target='_blank' href='https://coppermind.net/wiki/Ire'>Ire</a> to suspect <a target='_blank' href='https://coppermind.net/wiki/Shade'>Shades</a> from <a target='_blank' href='https://coppermind.net/wiki/Threnody'>Threnody</a> are nearby."
+                                },
+                                {
+                                    "target": "au",
+                                    "type": "minor",
+                                    "description": "The <a target='_blank' href='https://coppermind.net/wiki/Threnodite_system'>Threnodite system</a> essay discusses the history of <a target='_blank' href='https://coppermind.net/wiki/Threnody'>Threnody</a>."
+                                },
+                                {
+                                    "target": "sa4",
+                                    "type": "egg",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Raboniel'>Raboniel's</a> chain from 'the lands of the dead' is likely a <a target='_blank' href='https://coppermind.net/wiki/Silver'>silver</a> chain from <a target='_blank' href='https://coppermind.net/wiki/Threnody'>Threnody</a>."
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "children": [
+                        {
+                            "id": "db",
+                            "title": "The Dust Brigade",
+                            "title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=the+dust+brigade'>The Dust Brigade</a>",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Threnody'>Threnody</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Threnodite_system'>Threnodite system</a>",
+                            "categories": [ "no-series", "plan", "unpublished", "novel" ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "label": "First of<br>the Sun",
+            "color": "#367485",
+            "children": [
+                {
+                    "children": [
+                        {
+                            "id": "sotd",
+                            "title": "Sixth of the Dusk",
+                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Sixth_of_the_Dusk'>Sixth of the Dusk</a>",
+                            "series": "Sixth of<br>the Dusk",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/First_of_the_Sun'>First of the Sun</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Drominad_system'>Drominad system</a>",
+                            "au": "Included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
+                            "publication": "June 2014",
+                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/60/#e6664'>Shortly before Mistborn Era 4.</a>",
+                            "sorting": {
+				"order": 1.6,
+                                "publication": 2014.06,
+                                "chronology": 13.0
+                            },
+                            "categories": [ "no-series", "novella", "phase1b", "published" ],
+                            "connections": [
+                                {
+                                    "target": "sa3",
+                                    "type": "minor",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Mraize'>Mraize</a>'s chicken, mentioned in <a target='_blank' href='https://coppermind.net/wiki/Summary:Oathbringer#Chapter_22:_The_Darkness_Within'>Chapter 22</a>, is an <a target='_blank' href='https://coppermind.net/wiki/Aviar'>Aviar</a>. <a target='_blank' href='https://coppermind.net/wiki/Patji'>Patji</a> is referenced obliquely in <a target='_blank' href='https://coppermind.net/wiki/Autonomy'>Autonomy</a>'s <a target='_blank' href='https://coppermind.net/wiki/Letters#Second_Oathbringer_Letter'>letter</a> to <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> in the <a target='_blank' href='https://coppermind.net/wiki/Oathbringer/Epigraphs#Letters'>Part 2 epigraphs</a>."
+                                },
+                                {
+                                    "target": "au",
+                                    "type": "minor",
+                                    "description": "The <a target='_blank' href='https://coppermind.net/wiki/Drominad_system'>Drominad system</a> essay discusses <a target='_blank' href='https://coppermind.net/wiki/First_of_the_Sun'>First of the Sun</a> and its magic."
+                                },
+                                {
+                                    "target": "sa4",
+                                    "type": "minor",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Gereh'>Gereh</a> has an <a target='_blank' href='https://coppermind.net/wiki/Aviar'>Aviar</a>, which <a target='_blank' href='https://coppermind.net/wiki/Lift'>Lift</a> comes into possession of."
+                                }
+                            ]
+                        },
+                        {
+                            "id": "sotd2",
+                            "title": "Sixth of the Dusk sequel",
+                            "title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=sixth+of+the+dusk+sequel'>Sixth of the Dusk sequel</a>",
+                            "series": "Sixth of<br>the Dusk",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/First_of_the_Sun'>First of the Sun</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Drominad_system'>Drominad system</a>",
+                            "chronology": "Five years after Sixth of the Dusk.",
+                            "sorting": {
+                                "chronology": 13.02
+                            },
+                            "link": "<a target='_blank' href='https://wob.coppermind.net/events/448/#e14408'>Excerpt on Arcanum.</a> (some may consider to be spoilers)",
+                            "categories": [ "no-series", "novella", "plan", "unpublished" ]
+                        }
+                    ]
+                },
+                {
+                    "children": [
+                        {
+                            "id": "kingmaker",
+                            "title": "Kingmaker",
+                            "title2": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>Kingmaker</a>",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/First_of_the_Sun'>First of the Sun</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Drominad_system'>Drominad system</a>",
+                            "link": "<a target='_blank' href='https://wob.coppermind.net/events/479/#e15153'>Reading on Arcanum.</a>",
+                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/479/#e15153'>The reading suggests a setting not long after Sixth of the Dusk.</a>",
+                            "sorting": {
+                                "chronology": 13.01
+                            },
+                            "categories": [ "no-series", "novel", "plan", "unpublished" ]
+                        }
+				    ]
+                }
+            ]
+        },
+        {
+            "label": "Yolen",
+            "color": "#d98a41",
+            "children": [
+                {
+                    "label": "Dragonsteel",
+                    "children": [
+                        {
+                            "id": "d1",
+                            "title": "Dragonsteel 1",
+                            "title2": "Dragonsteel 1",
+                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Dragonsteel'>Dragonsteel</a>",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Yolen'>Yolen</a>",
+                            "system": "Yolish system",
+                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/103/#e1024'>Dragonsteel is the first series in the cosmere storyline.</a>",
+                            "sorting": {
+                                "chronology": 1.1
+                            },
+                            "categories": [ "dragonsteel", "plan", "unpublished", "novel" ],
+			    "connections": [
+				{
+				    "target": "mb7",
+				    "type": "egg",
+				    "description": "WIP"
+				}
+			]
+                        },
+                        {
+                            "id": "d2",
+                            "title": "Dragonsteel 2",
+                            "title2": "Dragonsteel 2",
+                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Dragonsteel'>Dragonsteel</a>",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Yolen'>Yolen</a>",
+                            "system": "Yolish system",
+                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/103/#e1024'>Dragonsteel is the first series in the cosmere storyline.</a>",
+                            "sorting": {
+                                "chronology": 1.2
+                            },
+                            "categories": [ "dragonsteel", "plan", "unpublished", "novel" ]
+                        },
+                        {
+                            "id": "d3",
+                            "title": "Dragonsteel 3",
+                            "title2": "Dragonsteel 3",
+                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Dragonsteel'>Dragonsteel</a>",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Yolen'>Yolen</a>",
+                            "system": "Yolish system",
+                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/103/#e1024'>Dragonsteel is the first series in the cosmere storyline.</a>",
+                            "sorting": {
+                                "chronology": 1.3
+                            },
+                            "categories": [ "dragonsteel", "plan", "unpublished", "novel" ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "label": "Other",
+            "color": "#a0a0a0",
+            "children": [
+                {
+                    "label": "Aether<br>Series",
+		    "color": "#e3a1e3",
+		    "children": [
+                        {
+                            "id": "aether1",
+                            "title": "Aether Book 1",
+                            "title2": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2019/'>Aether Book 1</a>",
+                            "world": "Unknown",
+                            "system": "Unknown",
+                            "categories": [ "aether", "novel", "plan", "unpublished" ]
+                        },
+                        {
+                            "id": "aether2",
+                            "title": "Aether Book 2",
+                            "title2": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2019/'>Aether Book 2</a>",
+                            "world": "Unknown",
+                            "system": "Unknown",
+                            "categories": [ "aether", "novel", "plan", "unpublished" ]
+                        },
+                        {
+                            "id": "aether3",
+                            "title": "Aether Book 3",
+                            "title2": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2019/'>Aether Book 3</a>",
+                            "world": "Unknown",
+                            "system": "Unknown",
+                            "categories": [ "aether", "novel", "plan", "unpublished" ]
+                        }
+                    ]
+                },
+                {
+                    "children": [
+                        {
+                            "id": "secret1",
+                            "title": "Secret Project 1 (2023)",
+                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Secret_Project_One'>Secret Project 1</a>",
+                            "world": "Spoiler",
+                            "system": "Spoiler",
+                            "publication": "January 2023",
+                            "sorting": {
+                                "publication": 2023.01
+                            },
+                            "link": "Chapters 1-5 available on <a target='_blank' href='brandonsanderson.com/first-look-at-secret-project-1'>Brandon's website</a> and <a target='_blank' href='https://youtu.be/bBUVXcIE0E0'>YouTube</a>. (some may consider to be spoilers)",
+                            "categories": [ "no-series", "novel", "plan", "forthcoming" ]
+                        }
+                    ]
+                },
+                {
+                    "children": [
+                        {
+                            "id": "secret3",
+                            "title": "Secret Project 3 (2023)",
+                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Secret_Project_Three'>Secret Project 3</a>",
+                            "world": "Spoiler",
+                            "system": "Spoiler",
+                            "publication": "July 2023",
+                            "sorting": {
+                                "publication": 2023.07
+                            },
+                            "link": "Chapters 1-7 available on <a target='_blank' href='brandonsanderson.com/first-look-at-secret-project-3'>Brandon's website</a> and <a target='_blank' href='https://youtu.be/cFGDcvtRdz0'>YouTube</a>. (some may consider to be spoilers)",
+                            "categories": [ "no-series", "novel", "plan", "forthcoming" ]
+                        }
+                    ]
+                },
+                {
+                    "children": [
+                        {
+                            "id": "secret4",
+                            "title": "Secret Project 4 (2023)",
+                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Secret_Project_Four'>Secret Project 4</a>",
+                            "world": "Spoiler",
+                            "system": "Spoiler",
+                            "publication": "October 2023",
+                            "sorting": {
+                                "publication": 2023.10
+                            },
+                            "categories": [ "no-series", "novel", "plan", "forthcoming" ]
+                        }
+                    ]
+                },
+                {
+                    "children": [
+                        {
+                            "id": "silverlight",
+                            "title": "Silverlight novella",
+                            "title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=silverlight+novella'>Silverlight novella</a>",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Cognitive_Realm'>Cognitive Realm</a>",
+                            "system": "N/A",
+                            "categories": [ "no-series", "novella", "plan", "unpublished" ]
+                        }
+                    ]
+                },
+                {
+                    "children": [
+                        {
+                            "id": "kite",
+                            "title": "Magic Kites YA story",
+                            "title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=kite+magic'>Kite-based magic story</a>",
+                            "world": "Unknown",
+                            "system": "Unknown",
+                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/379/#e12466'>Planned to take place between Mistborn Era 3 and 4.</a>",
+                            "sorting": {
+                                "chronology": 11.0
+                            },
+                            "categories": [ "no-series", "novella", "plan", "unpublished" ]
+                        }
+                    ]
+                },
+                {
+                    "children": [
+                        {
+                            "id": "au",
+                            "title": "Arcanum Unbounded (essays)",
+                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded (essays)</a>",
+                            "world": "N/A",
+                            "system": "N/A",
+                            "au": "Included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
+                            "publication": "November 2016",
+                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/36/#e1491'>The essays were written before the events of Sixth of the Dusk.</a> They could potentially be as early as Mistborn Era 3.",
+                            "sorting": {
+				"order": 2.3,
+                                "publication": 2016.11,
+                                "chronology": 12.0
+                            },
+                            "appearances": [
+                                {
+                                    "id": "khriss",
+                                    "type": "mention",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> is the author of the essays."
+                                }
+                            ],
+                            "categories": [ "no-series", "short", "phase2", "published" ],
+                            "connections": [
+                                {
+                                    "target": "sa4",
+                                    "type": "minor",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Devotion'>Devotion</a> and <a target='_blank' href='https://coppermind.net/wiki/Dominion'>Dominion</a> are referenced in the <a target='_blank' href='https://coppermind.net/wiki/Rhythm_of_War/Epigraphs'>Chapter 26 Epigraph</a>. <a target='_blank' href='https://coppermind.net/wiki/Ambition'>Ambition's</a> struggle with <a target='_blank' href='https://coppermind.net/wiki/Odium'>Odium</a> is referenced in the <a target='_blank' href='https://coppermind.net/wiki/Rhythm_of_War/Epigraphs'>Chapter 27 Epigraph</a>."
+                                },
+				{
+				    "target": "mb7",
+				    "type": "minor",
+				    "description": "WIP"
+				}
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "label": "Mixed",
+            "color": "#a0a0a0",
+            "children": [
+                {
+                    "children": [
+                        {
+                            "id": "wsp",
+                            "title": "White Sand (prose)",
+                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/White_Sand_(prose)'>White Sand (prose)</a>",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Taldain_system'>Taldain system</a>",
+                            "au": "Excerpt included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded.</a>.",
+                            "link": "<a target='_blank' href='https://brandonsanderson.com/newsletter-signup/'>Link to full text found in Brandon's newsletter.</a>",
+                            "publication": "June 2009 (upon request)",
+                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/182/#e3878'>White Sand occurs prior to Elantris.</a>",
+                            "sorting": {
+                                "order": 2.14,
+                                "publication": 2009.06,
+                                "chronology": 2.0
+                            },
+                            "appearances": [
+                                {
+                                    "id": "khriss",
+                                    "type": "appearance",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> is a main character."
+                                }
+                            ],
+                            "categories": [ "white-sand", "novel", "apocryphal", "noncanon" ],
+                            "connections": [
+                                {
+                                    "target": "ws1",
+                                    "type": "minor",
+                                    "description": "The <a target='_blank' href='https://coppermind.net/wiki/White_Sand'>White Sand</a> graphic novels are based on the prose version."
+                                }
+                            ]
+                        },
+                        {
+                            "id": "aon",
+                            "title": "Aether of Night",
+                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Aether_of_Night'>Aether of Night</a>",
+                            "world": "Unknown",
+                            "system": "Unknown",
+                            "link": "<a target='_blank' href='https://www.17thshard.com/forum/topic/60219-aether-of-night-manuscript-requests/'>Full text available from the 17th Shard.</a>",
+                            "publication": "June 2009 (upon request)",
+                            "sorting": {
+				                "order": 2.92,
+                                "publication": 2009.06
+                            },
+                            "categories": [ "no-series", "apocryphal", "noncanon", "novel" ],
+                            "connections": [
+                                {
+                                    "target": "sa2",
+                                    "type": "egg",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Mraize'>Mraize</a>'s collection in <a target='_blank' href='https://coppermind.net/wiki/Summary:Words_of_Radiance#Chapter_43:_The_Ghostbloods'>Chapter 43</a> includes pink <a target='_blank' href='https://coppermind.net/wiki/Aether'>aether</a>."
+                                },
+                                {
+                                    "target": "sa3",
+                                    "type": "egg",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Mraize'>Mraize</a> mentions his suit was stained with <a target='_blank' href='https://coppermind.net/wiki/Aether'>aether</a>."
+                                },
+                                {
+                                    "target": "sa4",
+                                    "type": "egg",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Foil'>Foil</a> is said to be seeking 'control over the <a target='_blank' href='https://coppermind.net/wiki/Aether'>aethers</a>'."
+                                },
+				{
+				    "target": "mb7",
+				    "type": "minor",
+				    "description": "WIP"
+				}
+                            ]
+                        },
+                        {
+                            "id": "imperial-fool",
+                            "title": "Imperial Fool",
+                            "title2": "Imperial Fool",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Sel'>Sel</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Selish_system'>Selish system</a>",
+                            "link": "<a target='_blank' href='https://brandonsanderson.com/the-emperors-soul-deleted-prologue-imperial-fool'>Full text on Brandon's website.</a>",
+                            "publication": "November 2012",
+                            "chronology": "Concerns events shortly before the events of The Emperor's Soul.",
+                            "sorting": {
+				                "order": 1.41,
+                                "publication": 2012.11,
+                                "chronology": 3.4
+                            },
+                            "appearances": [
+                                {
+                                    "id": "hoid",
+                                    "type": "appearance",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is the 'Imperial Fool'."
+                                }
+                            ],
+                            "categories": [ "no-series", "short", "apocryphal", "noncanon" ],
+			    "connections":[
+				{
+				    "target": "mb7",
+				    "type": "egg",
+				    "description": "WIP"
+				}
+			    ]
+                        },
+                        {
+                            "id": "twokp",
+                            "title": "The Way of Kings Prime",
+                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Way_of_Kings_Prime'>The Way of Kings Prime</a>",
+                            "series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+                            "link": "<a target='_blank' href='https://www.brandonsanderson.com/the-way-of-kings-prime/'>Full novel on Brandon's website.</a>",
+                            "publication": "July 2020",
+                            "sorting": {
+				                "order": 2.91,
+                                "publication": 2020.07
+                            },
+                            "categories": [ "stormlight", "novel", "apocryphal", "noncanon" ]
+                        },
+                        {
+                            "id": "jasnah",
+                            "title": "Jasnah deleted scene",
+                            "title2": "Jasnah deleted scene",
+                            "series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
+                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+                            "link": "<a target='_blank' href='https://www.tor.com/2014/08/06/stormlight-archive-scene-after-words-of-radiance'>Full text on Tor.com.</a>",
+                            "publication": "August 2014",
+                            "chronology": "Occurs during the early events of Words of Radiance.",
+                            "sorting": {
+				                "order": 2.421,
+                                "publication": 2014.08,
+                                "chronology": 7.021
+                            },
+                            "categories": [ "stormlight", "short", "apocryphal", "noncanon" ]
+                        },
+                        {
+                            "id": "traveler",
+                            "title": "The Traveler",
+                            "title2": "The Traveler",
+                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Yolen'>Yolen</a>",
+                            "system": "Yolish system",
+                            "link": "<a target='_blank' href='https://wob.coppermind.net/events/332/#e9518'>Full text on Arcanum.</a>",
+                            "publication": "April 2018",
+                            "chronology": "Occurs shortly after Mistborn Era 1.",
+                            "sorting": {
+                                "order": 2.26,
+                                "publication": 2018.04,
+                                "chronology": 4.5
+                            },
+                            "appearances": [
+                                {
+                                    "id": "hoid",
+                                    "type": "appearance",
+                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is 'the Traveler'."
+                                }
+                            ],
+                            "categories": [ "no-series", "short", "apocryphal", "noncanon" ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
 }

--- a/public/data.json
+++ b/public/data.json
@@ -800,7 +800,7 @@
 							"publication": "Fall 2022",
 							"chronology": "Mistborn Era 2 occurs <a target='_blank' href='https://wob.coppermind.net/events/260/#e8747'>after Stormlight Archive book 5</a> and <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>before Stormlight Archive book 6</a>.",
 							"sorting": {
-								"order": 2.27
+								"order": 2.27,
 								"publication": 2022.11,
 								"chronology": 8.4
 							},

--- a/public/data.json
+++ b/public/data.json
@@ -324,7 +324,7 @@
 								{
 									"target": "mb7",
 									"type": "major",
-									"description": "(WIP) Codenames is Kaise. Shay-I (Moonlight) uses AonDor in chapter 54. Codenames communicate with Kelsier using Seon Dao"
+									"description": "(WIP) Codenames is Kaise; she communicate with Kelsier using Seon Dao in chapter 40. Shay-I (Moonlight) uses AonDor in chapter 54."
 								}
 							]
 						},
@@ -438,7 +438,7 @@
 								{
 									"target": "mb7",
 									"type": "major",
-									"description": "(WIP) Moonlight is Shai; she uses Forgery on several occasions and takes on the name Shay-I after using her essence mark"
+									"description": "(WIP) Moonlight is Shai; she uses Forgery on several occasions and takes on the name Shay-I after using her essence mark."
 								}
 							]
 						},
@@ -824,6 +824,13 @@
 								"plan",
 								"forthcoming",
 								"novel"
+							],
+							"connections": [
+								{
+									"target": "mb7",
+									"type": "egg",
+									"description": "(WIP) The glowing jars the Ire are using might be purified Dor."
+								}
 							]
 						},
 						{
@@ -1032,11 +1039,6 @@
 									"target": "sa4",
 									"type": "significant",
 									"description": "Thaidakar, leader of the <a target='_blank' href='https://coppermind.net/wiki/Ghostbloods'>Ghostbloods</a> is <a target='_blank' href='https://coppermind.net/wiki/Kelsier'>Kelsier</a>, with the fight between him and <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> in <a target='_blank' href='https://coppermind.net/wiki/Mistborn:_Secret_History'>Secret History</a> specifically referenced. <a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a> is referenced in <a target='_blank' href='https://coppermind.net/wiki/Ialai'>Ialai's</a> notes. The device used by the <a target='_blank' href='https://coppermind.net/wiki/honorspren'>honorspren</a> to store <a target='_blank' href='https://coppermind.net/wiki/Stormlight'>Stormlight</a> came from the <a target='_blank' href='https://coppermind.net/wiki/Ire'>Ire</a>."
-								},
-								{
-									"target": "mb7",
-									"type": "significant",
-									"description": "(WIP) Kelsier's survival is made explicit in Secret History. The glowing jars that the Ire are using are likely purified Dor."
 								}
 							]
 						},
@@ -1712,11 +1714,6 @@
 									"target": "sa4",
 									"type": "minor",
 									"description": "<a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a> is referenced in <a target='_blank' href='https://coppermind.net/wiki/Ialai'>Ialai's</a> notes."
-								},
-								{
-									"target": "mb7",
-									"type": "minor",
-									"description": "(WIP) Aether manipulation drains the body's water supply similarly to Sand mastery."
 								}
 							]
 						},
@@ -2071,7 +2068,7 @@
 								{
 									"target": "mb7",
 									"type": "egg",
-									"description": "(WIP) A Sho Del is described in the epilogue."
+									"description": "(WIP) Jan Ven, mentioned in the epilogue, is a Sho Del–a race of beings first mentioned in Dragonsteel."
 								}
 							]
 						},
@@ -2305,7 +2302,7 @@
 								{
 									"target": "mb7",
 									"type": "minor",
-									"description": "(WIP) Moonlight references the death of Devotion and Dominion in chapter 40. Autonomy's original planet is revealed in The Taldain System Essay."
+									"description": "(WIP) Moonlight references the death of Devotion and Dominion in chapter 40. Autonomy currently resides in the Taldain system."
 								}
 							]
 						}
@@ -2392,7 +2389,7 @@
 								{
 									"target": "mb7",
 									"type": "minor",
-									"description": "(WIP) TwinSoul can manipulates the Aethers."
+									"description": "(WIP) TwinSoul can manipulate the Aethers."
 								}
 							]
 						},

--- a/public/data.json
+++ b/public/data.json
@@ -323,8 +323,8 @@
 								},
 								{
 									"target": "mb7",
-									"type": "major",
-									"description": "(WIP) Codenames is Kaise; she communicate with Kelsier using Seon Dao in Chapter 40. Shay-I (Moonlight) uses AonDor in Chapter 54."
+									"type": "significant",
+									"description": "Codenames is <a target='_blank' href='https://coppermind.net/wiki/Kaise'>Kaise</a>; she communicate with <a target='_blank' href='https://coppermind.net/wiki/Kelsier'>Kelsier</a> using <a target='_blank' href='https://coppermind.net/wiki/Seon'>Seon Dao</a> in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Lost_Metal#Chapter_40'>Chapter 40</a>. <a target='_blank' href='https://coppermind.net/wiki/Shay-I'>Shay-I (Moonlight)</a> uses <a target='_blank' href='https://coppermind.net/wiki/AonDor'>AonDor</a> in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Lost_Metal#Chapter_54'>Chapter 54</a>."
 								}
 							]
 						},
@@ -438,7 +438,7 @@
 								{
 									"target": "mb7",
 									"type": "major",
-									"description": "(WIP) Moonlight is Shai; she uses Forgery on several occasions and takes on the name Shay-I after using her essence mark."
+									"description": "Moonlight is <a target='_blank' href='https://coppermind.net/wiki/Shai'>Shai</a>; she uses <a target='_blank' href='https://coppermind.net/wiki/Forgery'>Forgery</a> on several occasions and takes on the name 'Shay-I' after using her <a target='_blank' href='https://coppermind.net/wiki/Essence_Mark'>Essence Mark</a>."
 								}
 							]
 						},
@@ -821,15 +821,15 @@
 							],
 							"categories": [
 								"mistborn",
-								"plan",
-								"forthcoming",
+								"phase2",
+								"published",
 								"novel"
 							],
 							"connections": [
 								{
 									"target": "mb7",
 									"type": "egg",
-									"description": "(WIP) The glowing jars the Ire are using might be purified Dor."
+									"description": "The glowing jars the <a target='_blank' href='https://coppermind.net/wiki/Ire'>Ire</a> are using might be purified <a target='_blank' href='https://coppermind.net/wiki/Dor'>Dor</a>."
 								}
 							]
 						},
@@ -1140,8 +1140,8 @@
 								},
 								{
 									"target": "mb7",
-									"type": "significant",
-									"description": "(WIP) Nalthis is mentionned in Chapter 39. Moonlight describes an Awakened lock in Chapter 40."
+									"type": "minor",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Nalthis'>Nalthis</a> is mentionned in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Lost_Metal#Chapter_39'>Chapter 39</a>. <a target='_blank' href='https://coppermind.net/wiki/Moonlight'>Moonlight</a> describes an <a target='_blank' href='https://coppermind.net/wiki/Awakening'>Awakened</a> lock in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Lost_Metal#Chapter_40'>Chapter 40</a>."
 								}
 							]
 						},
@@ -1208,7 +1208,7 @@
 								{
 									"target": "mb7",
 									"type": "minor",
-									"description": "(WIP) Moonlight mentions Odium in Chapter 20. Codenames mentions Roshar and the Thaylen language in Chapter 39."
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Moonlight'>Moonlight</a> mentions <a target='_blank' href='https://coppermind.net/wiki/Odium'>Odium</a> in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Lost_Metal#Chapter_20'>Chapter 20</a>. <a target='_blank' href='https://coppermind.net/wiki/Codenames'>Codenames</a> mentions <a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a> and the <a target='_blank' href='https://coppermind.net/wiki/Thaylen_script'>Thaylen script</a> in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Lost_Metal#Chapter_39'>Chapter 39</a>."
 								}
 							]
 						},
@@ -1267,7 +1267,7 @@
 								{
 									"target": "mb7",
 									"type": "egg",
-									"description": "(WIP) Wayne buys some chouta from a street vendor in Chapter 32. Dlavil is Iyatil's Brother"
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Wayne'>Wayne</a> buys some <a target='_blank' href='https://coppermind.net/wiki/Chouta'>chouta</a> from a street vendor in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Lost_Metal#Chapter_32'>Chapter 32</a>. <a target='_blank' href='https://coppermind.net/wiki/Dlavil'>Dlavil</a> is <a target='_blank' href='https://coppermind.net/wiki/Iyatil'>Iyatil</a>'s Brother"
 								}
 							]
 						},
@@ -2068,7 +2068,7 @@
 								{
 									"target": "mb7",
 									"type": "egg",
-									"description": "(WIP) Jan Ven, mentioned in the epilogue, is a Sho Del–a race of beings first mentioned in Dragonsteel."
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Jan_Ven'>Jan Ven</a>, mentioned in the <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Lost_Metal#Epilogue_6'>6th Epilogue</a>, is a <a target='_blank' href='https://coppermind.net/wiki/Sho_Del'>Sho Del</a>–a species of beings first mentioned in Dragonsteel."
 								}
 							]
 						},
@@ -2302,7 +2302,7 @@
 								{
 									"target": "mb7",
 									"type": "minor",
-									"description": "(WIP) Moonlight references the death of Devotion and Dominion in Chapter 40. Autonomy currently resides in the Taldain system."
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Moonlight'>Moonlight</a> references the death of <a target='_blank' href='https://coppermind.net/wiki/Devotion'>Devotion</a> and <a target='_blank' href='https://coppermind.net/wiki/Dominion'>Dominion</a> in Chapter 40. <a target='_blank' href='https://coppermind.net/wiki/Autonomy'>Autonomy</a> currently resides in the <a target='_blank' href='https://coppermind.net/wiki/Taldain_system'>Taldain system</a>."
 								}
 							]
 						}
@@ -2389,7 +2389,7 @@
 								{
 									"target": "mb7",
 									"type": "minor",
-									"description": "(WIP) TwinSoul can manipulate the Aethers."
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/TwinSoul'>TwinSoul</a> can manipulate the <a target='_blank' href='https://coppermind.net/wiki/Aether'>Aethers</a>."
 								}
 							]
 						},

--- a/public/data.json
+++ b/public/data.json
@@ -1,2142 +1,2502 @@
 {
-    "base-separation": 3.21,
-    "connections": [
-        {
-            "id": "major",
-            "description": "Major Connections",
-            "details": "There is at least one major connection between the books which will enhance your understanding of the plot and the Cosmere. Reading in this order is highly recommended, and reading out of order may be spoilery.",
-            "color": "#770000",
-            "highlightColor": "#DB1E1E",
-            "width": 2
-        },
-        {
-            "id": "significant",
-            "description": "Significant Connections",
-            "details": "There is at least one significant connection between the books which may enhance your understanding of the plot and the Cosmere. Reading in this order is recommended.",
-            "color": "#a0470d",
-            "highlightColor": "#a0470d",
-            "width": 2,
-            "dash": "4 2"
-        },
-        {
-            "id": "minor",
-            "description": "Minor Connections",
-            "details": "There is at least one minor connection between the books which may enhance your understanding of the plot and Cosmere in a small way.",
-            "color": "#a09713",
-            "highlightColor": "#a09713",
-            "width": 1,
-            "dash": "3",
-            "activeByDefault": false
-        },
-        {
-            "id": "egg",
-            "description": "Easter Eggs",
-            "details": "There is at least one subtle reference between the books which may hint at something bigger going on. Easter eggs may be very difficult to spot unaided.",
-            "color": "#4d4d4d",
-            "highlightColor": "#4d4d4d",
-            "width": 1,
-            "dash": "2",
-            "activeByDefault": false
-        }
-    ],
-    "layers": [
-        {
-            "id": "pub-status",
-            "name": "Publication Status",
-            "categories": [
-                {
-                    "id": "published",
-                    "description": "Published",
-                    "details": "Published, canonical works.",
-                    "color": "#FFFFFF"
-                },
-                {
-                    "id": "forthcoming",
-                    "description": "Forthcoming",
-                    "details": "Forthcoming works with a planned release month or which are being actively worked on. Expected publication dates may be in parenthesis. Titles may be tentative.",
-                    "color": "#888888"
-                },
-                {
-                    "id": "unpublished",
-                    "description": "Future Plans",
-                    "details": "Includes all planned future cosmere stories. Likelihood of publication varies. Expected publication dates may be in parenthesis. Titles are tentative.",
-                    "color": "#505050"
-                },
-                {
-                    "id": "noncanon",
-                    "description": "Other",
-                    "details": "Uncanonical works which are publicly available, both excerpts and complete.",
-                    "color": "#735a45"
-                }
-            ]
-        },
-        {
-            "id": "series",
-            "name": "Series",
-            "startActive": true,
-            "categories": [
-                {
-                    "id": "elantris",
-                    "description": "Elantris",
-                    "details": "Elantris and its sequels.",
-                    "color": "#58b06e"
-                },
-                {
-                    "id": "mistborn",
-                    "description": "Mistborn",
-                    "details": "Mistborn (all eras)",
-                    "color": "#9973bf"
-                },
-                {
-                    "id": "warbreaker",
-                    "description": "Warbreaker",
-                    "details": "Warbreaker and its sequel.",
-                    "color": "#de4343"
-                },
-                {
-                    "id": "stormlight",
-                    "description": "Stormlight Archive",
-                    "details": "The Stormlight Archive",
-                    "color": "#2aa1d4"
-                },
-                {
-                    "id": "white-sand",
-                    "description": "White Sand",
-                    "details": "White Sand and its sequels.",
-                    "color": "#d4c955"
-                },
-                {
-                    "id": "dragonsteel",
-                    "description": "Dragonsteel",
-                    "details": "Dragonsteel",
-                    "color": "#d98a41"
-                },
-                {
-                    "id": "aether",
-                    "description": "Aether",
-                    "details": "Aether series",
-                    "color": "#e3a1e3"
-                },
-                {
-                    "id": "no-series",
-                    "description": "Non-series Stories",
-                    "details": "Stories not part of a series.",
-                    "color": "#A0A0A0"
-                }
-            ]
-        },
-        {
-            "id": "reading-order",
-            "name": "Reading Order",
-            "categories": [
-                {
-                    "id": "phase1",
-                    "description": "Phase 1 - Essential",
-                    "details": "Essential Phase 1 stories should be read before moving to Phase 2.",
-                    "color": "#00b02b"
-                },
-                {
-                    "id": "phase1b",
-                    "description": "Phase 1 - Secondary",
-                    "details": "Secondary Phase 1 stories may be read during Phase 1 or anytime after.",
-                    "color": "#7bb088"
-                },
-                {
-                    "id": "phase2",
-                    "description": "Phase 2 - Essential",
-                    "details": "Essential Phase 2 stories should be read after all essential Phase 1 works and before moving to Phase 3.",
-                    "color": "#0094d4"
-                },
-                {
-                    "id": "phase2b",
-                    "description": "Phase 2 - Secondary",
-                    "details": "Secondary Phase 2 stories may be read during Phase 2 or anytime after.",
-                    "color": "#8abdd4"
-                },
-                {
-                    "id": "plan",
-                    "description": "Unpublished - Future Plans",
-                    "details": "Includes all planned future cosmere stories. Likelihood of publication varies. Known publication dates may be in parenthesis. Titles are tentative.",
-                    "color": "#505050"
-                },
-                {
-                    "id": "apocryphal",
-                    "description": "Unpublished - Apocryphal",
-                    "details": "Includes unpublished, apocryphal stories. Some elements may be part of the official continuity. Some may be published in the future while others will not.",
-                    "color": "#735a45"
-                }
-            ]
-        },
-        {
-            "id": "formats",
-            "name": "Formats",
-            "startCollapsed": true,
-            "categories": [
-                {
-                    "id": "novel",
-                    "description": "Novels",
-                    "details": "Full novels.",
-                    "color": "#fc4422"
-                },
-                {
-                    "id": "graphic",
-                    "description": "Graphic Novels",
-                    "details": "Graphic novels.",
-                    "style": "italic",
-                    "color": "#fe8062"
-                },
-                {
-                    "id": "novella",
-                    "description": "Novellas",
-                    "details": "Novellas.",
-                    "style": "italic",
-                    "color": "#ffc8ba"
-                },
-                {
-                    "id": "short",
-                    "description": "Short Stories",
-                    "details": "Short stories.",
-                    "style": "italic",
-                    "color": "#fbe8e6"
-                }
-            ]
-        }
-    ],
-    "sorting": [
-        {
-            "id": "order",
-            "description": "Reading order"
-        },
-        {
-            "id": "publication",
-            "description": "Publication date"
-        },
-        {
-            "id": "chronology",
-            "description": "Cosmere timeline"
-        }
-    ],
-    "appearances": [
-        {
-            "id": "hoid",
-            "description": "Hoid",
-            "initial": "H",
-            "color": "#A0A0A0",
-            "details": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a>'s appearances (solid) and mentions (outline)."
-        },
-        {
-            "id": "khriss",
-            "description": "Khriss",
-            "initial": "K",
-            "color": "#A0A0A0",
-            "details": "<a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a>'s appearances (solid) and mentions (outline), not counting the <a target='_blank' href='https://coppermind.net/wiki/Ars_Arcanum'>Ars Arcanum</a>."
-        },
-        {
-            "id": "nazh",
-            "description": "Nazh",
-            "initial": "N",
-            "color": "#A0A0A0",
-            "details": "<a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a>'s appearances (solid) and mentions (outline)."
-        },
-        {
-            "id": "ars",
-            "description": "Ars Arcanum",
-            "initial": "A",
-            "color": "#A0A0A0",
-            "details": "Stories that include an <a target='_blank' href='https://coppermind.net/wiki/Ars_Arcanum'>Ars Arcanum</a>."
-        }
-    ],
-    "books": [
-        {
-            "label": "Sel",
-            "color": "#58b06e",
-            "children": [
-                {
-                    "label": "Elantris",
-                    "children": [
-                        {
-                            "id": "elantris",
-                            "title": "Elantris",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Elantris'>Elantris</a>",
-                            "series": "Elantris",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Sel'>Sel</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Selish_system'>Selish system</a>",
-                            "publication": "April 2005",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/298/#e9926'>Occurs long before Mistborn Era 1, but not thousands of years before.</a>",
-                            "sorting": {
-				"order": 1.3,
-                                "publication": 2005.04,
-                                "chronology": 3.1
-                            },
-                            "appearances": [
-                                {
-                                    "id": "hoid",
-                                    "type": "appearance",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a>'s first appearance. <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is the beggar that works with <a target='_blank' href='https://coppermind.net/wiki/Sarene'>Sarene</a> in <a target='_blank' href='https://coppermind.net/wiki/Summary:Elantris#Chapter_58'>Chapter 58</a>. The tenth anniversary edition includes <a target='_blank' href='https://coppermind.net/wiki/Summary:Elantris#Postscript'>a postscript</a> with <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> in it."
-                                },
-                                {
-                                    "id": "nazh",
-                                    "type": "mention",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a>'s annotations can be found on the map of <a target='_blank' href='https://coppermind.net/wiki/Sycla'>Sycla</a>."
-                                },
-                                {
-                                    "id": "ars",
-                                    "type": "appearance"
-                                }
-                            ],
-                            "categories": [ "elantris", "phase1", "published", "novel" ],
-                            "connections": [
-                                {
-                                    "target": "tes",
-                                    "type": "minor",
-                                    "description": "The map in <a target='_blank' href='https://coppermind.net/wiki/Elantris'>Elantris</a> refers to '<a target='_blank' href='https://coppermind.net/wiki/Rose_Empire'>Rose Barbarians</a>'. There are mentions of <a target='_blank' href='https://coppermind.net/wiki/Svorden'>Svorden</a>, <a target='_blank' href='https://coppermind.net/wiki/Teod'>Teod</a>, and <a target='_blank' href='https://coppermind.net/wiki/Sycla'>Sycla</a>. When escaping the palace, <a target='_blank' href='https://coppermind.net/wiki/Shai'>Shai</a> runs into a <a target='_blank' href='https://coppermind.net/wiki/Shu-Dereth'>Derethi priest</a> (wearing red armor). When she steals the painting she inscribes an <a target='_blank' href='https://coppermind.net/wiki/Aon'>Aon Reo</a> in its place."
-                                },
-                                {
-                                    "target": "msh",
-                                    "type": "significant",
-                                    "description": "The <a target='_blank' href='https://coppermind.net/wiki/Ire'>Ire</a> are <a target='_blank' href='https://coppermind.net/wiki/Elantrian'>Elantrians</a>. Their symbol is <a target='_blank' href='https://coppermind.net/wiki/Aon'>Aon Ire</a>."
-                                },
-                                {
-                                    "target": "sa1",
-                                    "type": "egg",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Galladon'>Galladon</a> appears in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Way_of_Kings#Interlude_I-1:_Ishikk'>Interlude I-1</a> as 'Grump'. Note his use of 'sule' (friend) and 'kolo' (understand) as well as the <a target='_blank' href='https://coppermind.net/wiki/Duladel'>Dula</a> word 'kayana' (crazy). Also, <a target='_blank' href='https://coppermind.net/wiki/Aona'>Aona</a> and <a target='_blank' href='https://coppermind.net/wiki/Skai'>Skai</a> are mentioned in the <a target='_blank' href='https://coppermind.net/wiki/https://coppermind.net/wiki/The_Way_of_Kings/Epigraphs#The_Letter'>Chapter 22 epigraph</a>."
-                                },
-                                {
-                                    "target": "sa3",
-                                    "type": "minor",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Riino'>Riino</a>, the lighthouse owner in <a target='_blank' href='https://coppermind.net/wiki/Summary:Oathbringer#Chapter_97:_Riino'>Chapter 97</a>, is the <a target='_blank' href='https://coppermind.net/wiki/Hoed'>Hoed</a> <a target='_blank' href='https://coppermind.net/wiki/Raoden'>Raoden</a> and <a target='_blank' href='https://coppermind.net/wiki/Galladon'>Galladon</a> lowered into the <a target='_blank' href='https://coppermind.net/wiki/Devotion's_Perpendicularity'>mountain lake</a>."
-                                },
-                                {
-                                    "target": "au",
-                                    "type": "minor",
-                                    "description": "The nature of <a target='_blank' href='https://coppermind.net/wiki/Sel'>Sel</a>'s magic is discussed in the <a target='_blank' href='https://coppermind.net/wiki/Selish_system'>Selish system</a> essay."
-                                },
-                                {
-                                    "target": "sa4",
-                                    "type": "minor",
-                                    "description": "The communication box used by <a target='_blank' href='https://coppermind.net/wiki/Shallan'>Shallan</a> to communicate with <a target='_blank' href='https://coppermind.net/wiki/Mraize'>Mraize</a> and <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> contains a <a target='_blank' href='https://coppermind.net/wiki/Seon'>Seon</a>."
-                                },
-				{
-				    "target": "mb7",
-				    "type": "major",
-				    "description": "WIP"
-				}
-                            ]
-                        },
-                        {
-                            "id": "thoe",
-                            "title": "The Hope of Elantris",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Hope_of_Elantris'>The Hope of Elantris</a>",
-                            "series": "Elantris",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Sel'>Sel</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Selish_system'>Selish system</a>",
-                            "au": "Included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
-                            "link": "<a target='_blank' href='https://brandonsanderson.com/elantris-the-hope-of-elantris'>Full text on Brandon's website.</a>",
-                            "padding": 12,
-                            "publication": "January 2006",
-                            "chronology": "Shortly after the events of Elantris, and concerning events during the end of that book.",
-                            "sorting": {
-				"order": 1.31,
-                                "publication": 2006.01,
-                                "chronology": 3.11
-                            },
-                            "categories": [ "elantris", "phase1b", "published", "short" ]
-                        },
-                        {
-                            "id": "elantris2",
-                            "title": "Elantris 2",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Elantris_sequel'>Elantris 2</a>",
-                            "series": "Elantris",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Sel'>Sel</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Selish_system'>Selish system</a>",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/395/#e13072'>A short time jump is planned between Elantris books, with the original main characters still being alive.</a>",
-                            "sorting": {
-                                "chronology": 3.2
-                            },
-                            "categories": [ "elantris", "plan", "unpublished", "novel" ]
-                        },
-                        {
-                            "id": "elantris3",
-                            "title": "Elantris 3",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Elantris_finale'>Elantris 3</a>",
-                            "series": "Elantris",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Sel'>Sel</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Selish_system'>Selish system</a>",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/395/#e13072'>A short time jump is planned between Elantris books, with the original main characters still being alive.</a>",
-                            "sorting": {
-                                "chronology": 3.3
-                            },
-                            "categories": [ "elantris", "plan", "unpublished", "novel" ]
-                        }
-                    ]
-                },
-                {
-                    "children": [
-                        {
-                            "id": "tes",
-                            "title": "The Emperor's Soul",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Emperor&#39s_Soul'>The Emperor's Soul</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Sel'>Sel</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Selish_system'>Selish system</a>",
-                            "au": "Included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
-                            "publication": "November 2012",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/109/#e1410'>After Elantris, but within the characters' lifetimes.</a> Note this could place it prior to Elantris 2 and/or 3.",
-                            "sorting": {
-				"order": 1.4,
-                                "publication": 2012.11,
-                                "chronology": 3.5
-                            },
-                            "appearances": [
-                                {
-                                    "id": "hoid",
-                                    "type": "mention",
-                                    "description": "The 'Imperial Fool' is <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a>."
-                                }
-                            ],
-                            "categories": [ "no-series", "phase1b", "published", "novella" ],
-                            "connections": [
-                                {
-                                    "target": "imperial-fool",
-                                    "type": "major",
-                                    "description": "A deleted prologue that contains some canonical elements."
-                                },
-                                {
-                                    "target": "au",
-                                    "type": "minor",
-                                    "description": "The nature of <a target='_blank' href='https://coppermind.net/wiki/Sel'>Sel</a>'s magic is discussed in the <a target='_blank' href='https://coppermind.net/wiki/Selish_system'>Selish system</a> essay."
-                                },
-                                {
-                                    "target": "sa4",
-                                    "type": "egg",
-                                    "description": "The <a target='_blank' href='https://coppermind.net/wiki/Fused'>Fused</a> refer to <a target='_blank' href='https://coppermind.net/wiki/aluminum'>aluminum</a> as Ralkalest."
-                                },
-				{
-				    "target": "mb7",
-				    "type": "major",
-				    "description": "WIP"
-				}
-                            ]
-                        },
-                        {
-                            "id": "tes2",
-                            "title": "The Emperor's Soul sequel",
-                            "title2": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>Untitled Emperor's Soul sequel</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Sel'>Sel</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Selish_system'>Selish system</a>",
-                            "categories": [ "no-series", "plan", "unpublished", "novella" ]
-                        }
-                    ]
-                }
-            ]
-        },
-        {
-            "label": "Scadrial",
-            "color": "#9973bf",
-            "children": [
-                {
-                    "label": "Mistborn<br>Era 1",
-                    "children": [
-                        {
-                            "id": "mb1",
-                            "title": "Mistborn: The Final Empire",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn:_The_Final_Empire'>Mistborn: The Final Empire</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 1)",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-                            "publication": "July 2006",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/176/#e8494'>Mistborn Era 1 occurs prior to The Stormlight Archive.",
-                            "sorting": {
-				"order": 1.11,
-                                "publication": 2006.07,
-                                "chronology": 4.1
-                            },
-                            "appearances": [
-                                {
-                                    "id": "hoid",
-                                    "type": "appearance",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Kelsier'>Kelsier</a> meets with <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> in <a target='_blank' href='https://coppermind.net/wiki/Summary:Mistborn:_The_Final_Empire#Chapter_19'>Chapter 19</a>."
-                                },
-                                {
-                                    "id": "nazh",
-                                    "type": "mention",
-                                    "description": "Annotations by <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> can be found on the map of <a target='_blank' href='https://coppermind.net/wiki/Luthadel'>Luthadel</a>."
-                                },
-                                {
-                                    "id": "ars",
-                                    "type": "appearance"
-                                }
-                            ],
-                            "categories": [ "mistborn", "phase1", "published", "novel" ]
-                        },
-                        {
-                            "id": "11m",
-                            "title": "The Eleventh Metal",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Eleventh_Metal'>The Eleventh Metal</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 1)",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-                            "au": "Included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
-                            "padding": 12,
-                            "publication": "December 2011",
-                            "chronology": "Concerns Kelsier's training, years before Mistborn: The Final Empire.",
-                            "sorting": {
-				"order": 1.14,
-                                "publication": 2011.12,
-                                "chronology": 4.09
-                            },
-                            "categories": [ "mistborn", "short", "phase1b", "published" ]
-                        },
-                        {
-                            "id": "mb2",
-                            "title": "The Well of Ascension",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Well_of_Ascension'>The Well of Ascension</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 1)",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-                            "publication": "August 2007",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/176/#e8494'>Mistborn Era 1 occurs prior to The Stormlight Archive.",
-                            "sorting": {
-				"order": 1.12,
-                                "publication": 2007.08,
-                                "chronology": 4.2
-                            },
-                            "appearances": [
-                                {
-                                    "id": "hoid",
-                                    "type": "appearance",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is among the <a target='_blank' href='https://coppermind.net/wiki/Terris'>Terris</a> refugees in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Well_of_Ascension#Chapter_56'>Chapter 56</a>, <a target='_blank' href='https://wob.coppermind.net/events/130/#e1552'>according to Brandon</a>."
-                                },
-                                {
-                                    "id": "nazh",
-                                    "type": "mention",
-                                    "description": "Annotations by <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> can be found on the map of <a target='_blank' href='https://coppermind.net/wiki/Luthadel'>Luthadel</a>."
-                                },
-                                {
-                                    "id": "ars",
-                                    "type": "appearance"
-                                }
-                            ],
-                            "categories": [ "mistborn", "phase1", "published", "novel" ],
-                            "connections": [
-                                {
-                                    "target": "wb",
-                                    "type": "egg",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Lemex%27s_nurse'>Lemex's nurse</a> is a <a target='_blank' href='https://coppermind.net/wiki/Terris'>Terriswoman</a>."
-                                }
-                            ]
-                        },
-                        {
-                            "id": "mb3",
-                            "title": "The Hero of Ages",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Hero_of_Ages'>The Hero of Ages</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 1)",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-                            "publication": "October 2008",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/176/#e8494'>Mistborn Era 1 occurs prior to The Stormlight Archive.",
-                            "sorting": {
-				"order": 1.13,
-                                "publication": 2008.10,
-                                "chronology": 4.3
-                            },
-                            "appearances": [
-                                {
-                                    "id": "hoid",
-                                    "type": "mention",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is the informant that <a target='_blank' href='https://coppermind.net/wiki/Vin'>Vin</a> was supposed to meet with in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Hero_of_Ages#Chapter_27'>Chapter 27</a>."
-                                },
-                                {
-                                    "id": "nazh",
-                                    "type": "mention",
-                                    "description": "Annotations by <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> can be found on the map of <a target='_blank' href='https://coppermind.net/wiki/Luthadel'>Luthadel</a>."
-                                },
-                                {
-                                    "id": "ars",
-                                    "type": "appearance"
-                                }
-                            ],
-                            "categories": [ "mistborn", "phase1", "published", "novel" ],
-                            "connections": [
-                                {
-                                    "target": "sa1",
-                                    "type": "egg",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Demoux'>Demoux</a> appears in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Way_of_Kings#Interlude_I-1:_Ishikk'>Interlude I-1</a> as 'Thinker'; <a target='_blank' href='https://coppermind.net/wiki/Ishikk'>Ishikk</a> mishears his name as 'Temoo'. <a target='_blank' href='https://coppermind.net/wiki/Ruin'>Ruin</a>'s <a target='_blank' href='https://coppermind.net/wiki/vessel'>vessel</a>, <a target='_blank' href='https://coppermind.net/wiki/Ati'>Ati</a>, is mentioned in the <a target='_blank' href='https://coppermind.net/wiki/https://coppermind.net/wiki/The_Way_of_Kings/Epigraphs#The_Letter'>Chapter 18 epigraph</a>. <a target='_blank' href='https://coppermind.net/wiki/Felt'>Felt</a> worked for the <a target='_blank' href='https://coppermind.net/wiki/House_Venture'>House Venture</a> on <a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>."
-                                },
-                                {
-                                    "target": "sa2",
-                                    "type": "egg",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Wit</a> appears to use <a target='_blank' href='https://coppermind.net/wiki/Allomancy'>emotional Allomancy</a> in <a target='_blank' href='https://coppermind.net/wiki/Summary:Words_of_Radiance#Chapter_45:_Middlefest'>Chapter 45</a>."
-                                },
-                                {
-                                    "target": "sa3",
-                                    "type": "significant",
-                                    "description": "The <a target='_blank' href='https://coppermind.net/wiki/Oathbringer/Epigraphs#Letters'>Part 2 epigraphs</a> include <a target='_blank' href='https://coppermind.net/wiki/Letters#Third_Oathbringer_Letter'>a letter</a> from <a target='_blank' href='https://coppermind.net/wiki/Sazed'>Sazed</a> to <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a>. <a target='_blank' href='https://coppermind.net/wiki/Felt'>Felt</a> reveals he is from another world."
-                                },
-                                {
-                                    "target": "au",
-                                    "type": "major",
-                                    "description": "The <a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a> essay discusses the events that occurred in <a target='_blank' href='https://coppermind.net/wiki/The_Hero_of_Ages'>The Hero of Ages</a>."
-                                },
-                                {
-                                    "target": "sa4",
-                                    "type": "significant",
-                                    "description": "The <a target='_blank' href='https://coppermind.net/wiki/Rhythm_of_War/Epigraphs'>Part 2 Epigraphs</a> are a letter from <a target='_blank' href='https://coppermind.net/wiki/Harmony'>Harmony</a>. <a target='_blank' href='https://coppermind.net/wiki/Fabrial'>Fabrial</a> metals have similar effects as in the <a target='_blank' href='https://coppermind.net/wiki/Metallic_Arts'>Metalic Arts</a>. <a target='_blank' href='https://coppermind.net/wiki/Gereh'>Gereh</a> and <a target='_blank' href='https://coppermind.net/wiki/Axindweth'>Axindweth</a> are <a target='_blank' href='https://coppermind.net/wiki/Feruchemy'>Feruchemists</a>. <a target='_blank' href='https://coppermind.net/wiki/Raysium'>Raysium</a> is associated with <a target='_blank' href='https://coppermind.net/wiki/Odium'>Odium</a> as <a target='_blank' href='https://coppermind.net/wiki/atium'>atium</a> is associated with <a target='_blank' href='https://coppermind.net/wiki/Ruin'>Ruin</a>."
-                                }
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "label": "Mistborn<br>Era 2",
-                    "children": [
-                        {
-                            "id": "mb4",
-                            "title": "The Alloy of Law",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Alloy_of_Law'>The Alloy of Law</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 2)",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-                            "publication": "November 2011",
-                            "chronology": "Mistborn Era 2 occurs <a target='_blank' href='https://wob.coppermind.net/events/260/#e8747'>after Stormlight Archive book 5</a> and <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>before Stormlight Archive book 6</a>.",
-                            "sorting": {
-				"order": 2.21,
-                                "publication": 2011.11,
-                                "chronology": 8.1
-                            },
-                            "appearances": [
-                                {
-                                    "id": "hoid",
-                                    "type": "appearance",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is the beggar speaking with <a target='_blank' href='https://coppermind.net/wiki/Joshin_Yomen'>Lord Joshin</a> and <a target='_blank' href='https://coppermind.net/wiki/Mi%27chelle_Yomen'>Lady Mi'chelle</a> in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Alloy_of_Law#Chapter_4'>Chapter 4</a>."
-                                },
-                                {
-                                    "id": "nazh",
-                                    "type": "mention",
-                                    "description": "Annotations by <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> can be found on the map of <a target='_blank' href='https://coppermind.net/wiki/Elendel'>Elendel</a>."
-                                },
-                                {
-                                    "id": "ars",
-                                    "type": "appearance"
-                                }
-                            ],
-                            "categories": [ "mistborn", "phase2", "published", "novel" ]
-                        },
-                        {
-                            "id": "jak",
-                            "title": "Allomancer Jak",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Allomancer_Jak_and_the_Pits_of_Eltania'>Allomancer Jak and the Pits of Eltania</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 2)",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-                            "au": "Included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
-                            "padding": 12,
-                            "publication": "August 2014",
-                            "chronology": "Mistborn Era 2 occurs <a target='_blank' href='https://wob.coppermind.net/events/260/#e8747'>after Stormlight Archive book 5</a> and <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>before Stormlight Archive book 6</a>.",
-                            "sorting": {
-				"order": 2.22,
-                                "publication": 2014.08,
-                                "chronology": 8.05
-                            },
-                            "categories": [ "mistborn", "short", "phase2b", "published" ]
-                        },
-                        {
-                            "id": "mb5",
-                            "title": "Shadows of Self",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Shadows_of_Self'>Shadows of Self</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 2)",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-                            "publication": "October 2015",
-                            "chronology": "Mistborn Era 2 occurs <a target='_blank' href='https://wob.coppermind.net/events/260/#e8747'>after Stormlight Archive book 5</a> and <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>before Stormlight Archive book 6</a>.",
-                            "sorting": {
-				"order": 2.23,
-                                "publication": 2015.10,
-                                "chronology": 8.2
-                            },
-                            "appearances": [
-                                {
-                                    "id": "hoid",
-                                    "type": "appearance",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is <a target='_blank' href='https://coppermind.net/wiki/Waxillium_Laddrian'>Wax</a>'s coachman, named in <a target='_blank' href='https://coppermind.net/wiki/Summary:Shadows_of_Self#Chapter_7'>Chapter 7</a>."
-                                },
-                                {
-                                    "id": "ars",
-                                    "type": "appearance"
-                                }
-                            ],
-                            "categories": [ "mistborn", "phase2", "published", "novel" ]
-                        },
-                        {
-                            "id": "mb6",
-                            "title": "The Bands of Mourning",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Bands_of_Mourning'>The Bands of Mourning</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 2)",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-                            "publication": "January 2016",
-                            "chronology": "Mistborn Era 2 occurs <a target='_blank' href='https://wob.coppermind.net/events/260/#e8747'>after Stormlight Archive book 5</a> and <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>before Stormlight Archive book 6</a>.",
-                            "sorting": {
-				"order": 2.24,
-                                "publication": 2016.01,
-                                "chronology": 8.3
-                            },
-                            "appearances": [
-                                {
-                                    "id": "hoid",
-                                    "type": "appearance",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is the beggar who gives <a target='_blank' href='https://coppermind.net/wiki/Waxillium_Laddrian'>Wax</a> a special coin in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Bands_of_Mourning#Chapter_11'>Chapter 11</a>."
-                                },
-                                {
-                                    "id": "khriss",
-                                    "type": "appearance",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> is the woman who dances with <a target='_blank' href='https://coppermind.net/wiki/Waxillium_Laddrian'>Wax</a> in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Bands_of_Mourning#Chapter_12'>Chapter 12</a>. <a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> and <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> are also the 'K or N' referred to in the 'Do your metal tools speak to you?' ad in <a target='_blank' href='https://coppermind.net/wiki/The_New_Ascendancy'>The New Ascendancy</a> broadsheet."
-                                },
-                                {
-                                    "id": "nazh",
-                                    "type": "mention",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> is 'the haunted man' in 'The Ghastly Gondola!' story in <a target='_blank' href='https://coppermind.net/wiki/The_New_Ascendancy'>The New Ascendancy</a> broadsheet. (note his 'shadows' curse) <a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> and <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> are also the 'K or N' referred to in the 'Do your metal tools speak to you?' ad in the broadsheet."
-                                },
-                                {
-                                    "id": "ars",
-                                    "type": "appearance"
-                                }
-                            ],
-                            "categories": [ "mistborn", "phase2", "published", "novel" ],
-                            "connections": [
-                                {
-                                    "target": "sa2",
-                                    "type": "egg",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Iyatil'>Iyatil</a> is of <a target='_blank' href='https://coppermind.net/wiki/Southern_Scadrial'>Southern Scadrian</a> descent."
-                                },
-                                {
-                                    "target": "msh",
-                                    "type": "major",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Kelsier'>Kelsier</a>'s survival is revealed in <a target='_blank' href='https://coppermind.net/wiki/The_Bands_of_Mourning'>The Bands of Mourning</a>."
-                                },
-                                {
-                                    "target": "sotd2",
-                                    "type": "minor",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrian</a> spaceships powered by <a target='_blank' href='https://coppermind.net/wiki/Allomancy'>Allomancy</a> are seen."
-                                }
-                            ]
-                        },
-                        {
-                            "id": "mb7",
-                            "title": "The Lost Metal (2022)",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Lost_Metal'>The Lost Metal</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 2)",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-                            "publication": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>Fall 2022</a>",
-                            "chronology": "Mistborn Era 2 occurs <a target='_blank' href='https://wob.coppermind.net/events/260/#e8747'>after Stormlight Archive book 5</a> and <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>before Stormlight Archive book 6</a>.",
-                            "sorting": {
-                                "publication": 2022.11,
-                                "chronology": 8.4
-                            },
-                            "appearances": [
-                                {
-                                    "id": "hoid",
-                                    "type": "appearance",
-                                    "description": "WIP"
-                                },
-                                {
-                                    "id": "nazh",
-                                    "type": "mention",
-                                    "description": "WIP"
-                                },
-                                {
-                                    "id": "ars",
-                                    "type": "appearance"
-                                }
-                            ],
-                            "categories": [ "mistborn", "plan", "forthcoming", "novel" ]
-                        },
-                        {
-                            "id": "nicki",
-                            "title": "Boatload of Mummies",
-                            "title2": "<a target='_blank' href='https://wob.coppermind.net/events/479/#e15159'>Boatload of Mummies</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 2)",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-                            "chronology": "Mistborn Era 2 occurs <a target='_blank' href='https://wob.coppermind.net/events/260/#e8747'>after Stormlight Archive book 5</a> and <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>before Stormlight Archive book 6</a>.",
-                            "padding": 12,
-                            "sorting": {
-                                "chronology": 8.5
-                            },
-                            "categories": [ "mistborn", "short", "plan", "unpublished" ]
-                        }
-                    ]
-                },
-                {
-                    "label": "Mistborn<br>Era 3",
-                    "children": [
-                        {
-                            "id": "mb8",
-                            "title": "Mistborn Era 3 Book 1",
-                            "title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=mistborn+era+3'>Mistborn Era 3 Book 1</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 3)",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>Fifty to seventy years after Mistborn Era 2. After Stormlight Archive book 10.</a> Prior to Mistborn Era 4.",
-                            "publication": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>2024 (best guess)</a>",
-                            "sorting": {
-                                "chronology": 10.1,
-								"publication": 2024
-                            },
-                            "categories": [ "mistborn", "plan", "unpublished", "novel" ]
-                        },
-                        {
-                            "id": "mb9",
-                            "title": "Mistborn Era 3 Book 2",
-                            "title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=mistborn+era+3'>Mistborn Era 3 Book 2</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 3)",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>Fifty to seventy years after Mistborn Era 2. After Stormlight Archive book 10.</a> Prior to Mistborn Era 4.",
-                            "publication": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>2025 (best guess)</a>",
-                            "sorting": {
-                                "chronology": 10.2,
-								"publication": 2025
-                            },
-                            "categories": [ "mistborn", "plan", "unpublished", "novel" ]
-                        },
-                        {
-                            "id": "mb10",
-                            "title": "Mistborn Era 3 Book 3",
-                            "title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=mistborn+era+3'>Mistborn Era 3 Book 3</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 3)",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>Fifty to seventy years after Mistborn Era 2. After Stormlight Archive book 10.</a> Prior to Mistborn Era 4.",
-                            "publication": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>2026 (best guess)</a>",
-                            "sorting": {
-                                "chronology": 10.3,
-								"publication": 2026
-                            },
-                            "categories": [ "mistborn", "plan", "unpublished", "novel" ]
-                        }
-                    ]
-                },
-                {
-                    "label": "Mistborn<br>Era 4",
-                    "children": [
-                        {
-                            "id": "mb11",
-                            "title": "Mistborn Era 4 Book 1",
-                            "title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=mistborn+era+4'>Mistborn Era 4 Book 1</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 4)",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/182/#e3884'>Mistborn Era 4 is the finale of the cosmere storyline.</a>",
-                            "sorting": {
-                                "chronology": 13.1
-                            },
-                            "categories": [ "mistborn", "plan", "unpublished", "novel" ]
-                        },
-                        {
-                            "id": "mb12",
-                            "title": "Mistborn Era 4 Book 2",
-                            "title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=mistborn+era+4'>Mistborn Era 4 Book 2</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 4)",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/182/#e3884'>Mistborn Era 4 is the finale of the cosmere storyline.</a>",
-                            "sorting": {
-                                "chronology": 13.2
-                            },
-                            "categories": [ "mistborn", "plan", "unpublished", "novel" ]
-                        },
-                        {
-                            "id": "mb13",
-                            "title": "Mistborn Era 4 Book 3",
-                            "title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=mistborn+era+4'>Mistborn Era 4 Book 3</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 4)",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/182/#e3884'>Mistborn Era 4 is the finale of the cosmere storyline.</a>",
-                            "sorting": {
-                                "chronology": 13.3
-                            },
-                            "categories": [ "mistborn", "plan", "unpublished", "novel" ]
-                        }
-                    ]
-                },
-                {
-                    "label": "Other<br>Mistborn",
-                    "children": [
-                        {
-                            "id": "msh",
-                            "title": "Mistborn: Secret History",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn:_Secret_History'>Mistborn: Secret History</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-                            "au": "Included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
-                            "publication": "January 2016",
-                            "chronology": "Happens concurrently with Mistborn Era 1.",
-                            "sorting": {
-				"order": 2.25,
-                                "publication": 2016.01,
-                                "chronology": 4.11
-                            },
-                            "appearances": [
-                                {
-                                    "id": "hoid",
-                                    "type": "appearance",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is 'Drifter'."
-                                },
-                                {
-                                    "id": "khriss",
-                                    "type": "appearance",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Kelsier'>Kelsier</a> meets <a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> and <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> in the <a target='_blank' href='https://coppermind.net/wiki/Cognitive_Realm'>Cognitive Realm</a>."
-                                },
-                                {
-                                    "id": "nazh",
-                                    "type": "appearance",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Kelsier'>Kelsier</a> meets <a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> and <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> in the <a target='_blank' href='https://coppermind.net/wiki/Cognitive_Realm'>Cognitive Realm</a>."
-                                }
-                            ],
-                            "categories": [ "mistborn", "novella", "phase2", "published" ],
-                            "connections": [
-                                {
-                                    "target": "sa1",
-                                    "type": "egg",
-                                    "description": "In <a target='_blank' href='https://coppermind.net/wiki/Summary:Mistborn:_Secret_History#Chapter_2_5'>Part 5 Chapter 2</a> <a target='_blank' href='https://coppermind.net/wiki/Kelsier'>Kelsier</a> sees an <a target='_blank' href='https://coppermind.net/wiki/Fabrial'>alerter fabrial</a> (the glowing yellow gemstone in a golden metal lattice)."
-                                },
-                                {
-                                    "target": "sa2",
-                                    "type": "egg",
-                                    "description": "With powers gained from the <a target='_blank' href='https://coppermind.net/wiki/lerasium'>lerasium</a> he took, <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> uses <a target='_blank' href='https://coppermind.net/wiki/Allomancy'>emotional Allomancy</a> in <a target='_blank' href='https://coppermind.net/wiki/Summary:Words_of_Radiance#Chapter_45:_Middlefest'>Chapter 45</a>."
-                                },
-                                {
-                                    "target": "traveler",
-                                    "type": "major",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> and <a target='_blank' href='https://coppermind.net/wiki/Frost'>Frost</a> discuss the events of <a target='_blank' href='https://coppermind.net/wiki/The_Hero_of_Ages'>The Hero of Ages</a> (and <a target='_blank' href='https://coppermind.net/wiki/Mistborn:_Secret_History'>Mistborn: Secret History</a>)."
-                                },
-                                {
-                                    "target": "sa4",
-                                    "type": "significant",
-                                    "description": "Thaidakar, leader of the <a target='_blank' href='https://coppermind.net/wiki/Ghostbloods'>Ghostbloods</a> is <a target='_blank' href='https://coppermind.net/wiki/Kelsier'>Kelsier</a>, with the fight between him and <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> in <a target='_blank' href='https://coppermind.net/wiki/Mistborn:_Secret_History'>Secret History</a> specifically referenced. <a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a> is referenced in <a target='_blank' href='https://coppermind.net/wiki/Ialai'>Ialai's</a> notes. The device used by the <a target='_blank' href='https://coppermind.net/wiki/honorspren'>honorspren</a> to store <a target='_blank' href='https://coppermind.net/wiki/Stormlight'>Stormlight</a> came from the <a target='_blank' href='https://coppermind.net/wiki/Ire'>Ire</a>."
-                                },
-				{
-				    "target": "mb7",
-				    "type": "significant",
-				    "description": "WIP"
-				}
-                            ]
-                        },
-                        {
-                            "id": "msh2",
-                            "title": "Mistborn: Secret History 2",
-                            "title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=mistborn%3A+secret+history+2'>Mistborn: Secret History 2</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-                            "categories": [ "mistborn", "novella", "plan", "unpublished" ]
-                        },
-						{
-                            "id": "mb-cyberpunk",
-                            "title": "Cyberpunk Mistborn",
-                            "title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?query=cyberpunk%2Bmistborn&date_from=2003-12-05&date_to=2019-11-20&speaker=&ordering=rank'>Cyberpunk Mistborn</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-                            "chronology": "A cyberpunk Mistborn series would be in a <a target='_blank' href='https://wob.coppermind.net/events/34/#e1782'>near-future setting</a>, between Eras 3 and 4.",
-                            "sorting": {
-                                "chronology": 10.7
-                            },
-                            "categories": [ "mistborn", "plan", "unpublished", "novel" ]
-                        }
-                    ]
-                }
-            ]
-        },
-        {
-            "label": "Nalthis",
-            "color": "#de4343",
-            "children": [
-                {
-                    "label": "Warbreaker",
-                    "color": "#de4343",
-                    "children": [
-                        {
-                            "id": "wb",
-                            "title": "Warbreaker",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Warbreaker'>Warbreaker</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Nalthis'>Nalthis</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Nalthian_system'>Nalthian system</a>",
-                            "publication": "June 2009",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/309/#e10273'>Occurs after Mistborn Era 1 and before The Stormlight Archive.</a>",
-                            "link": "Full text: <a target='_blank' href='https://www.brandonsanderson.com/warbreaker-rights-and-downloads/'>Brandon's website</a> | <a target='_blank' href='https://github.com/guusj/books'>Alternate file types</a>",
-			    "sorting": {
-				"order": 1.2,
-                                "publication": 2009.06,
-                                "chronology": 5.1
-                            },
-                            "appearances": [
-                                {
-                                    "id": "hoid",
-                                    "type": "appearance",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is the master storyteller in <a target='_blank' href='https://coppermind.net/wiki/Summary:Warbreaker#Chapter_32'>Chapter 32</a>."
-                                },
-                                {
-                                    "id": "ars",
-                                    "type": "appearance"
-                                }
-                            ],
-                            "categories": [ "warbreaker", "phase1", "published", "novel" ],
-                            "connections": [
-                                {
-                                    "target": "sa2",
-                                    "type": "significant",
-                                    "description": "Zahel is <a target='_blank' href='https://coppermind.net/wiki/Vasher'>Vasher</a>. <a target='_blank' href='https://coppermind.net/wiki/Szeth'>Szeth</a>'s new <a target='_blank' href='https://coppermind.net/wiki/Shardblade'>Shardblade</a> is <a target='_blank' href='https://coppermind.net/wiki/Nightblood'>Nightblood</a>. <a target='_blank' href='https://coppermind.net/wiki/Mraize'>Mraize</a>'s collection in <a target='_blank' href='https://coppermind.net/wiki/Summary:Words_of_Radiance#Chapter_43:_The_Ghostbloods'>Chapter 43</a> includes a <a target='_blank' href='https://coppermind.net/wiki/Tears_of_Edgli'>Tear of Edgli</a> flower."
-                                },
-                                {
-                                    "target": "sa3",
-                                    "type": "major",
-                                    "description": "Azure is <a target='_blank' href='https://coppermind.net/wiki/Vivenna'>Vivenna</a>; she uses <a target='_blank' href='https://coppermind.net/wiki/Awakening'>Awakening</a> on several occaisions and has an Awakened sword. <a target='_blank' href='https://coppermind.net/wiki/Nightblood'>Nightblood</a> and <a target='_blank' href='https://coppermind.net/wiki/Vasher'>Vasher</a> make significant appearances. <a target='_blank' href='https://coppermind.net/wiki/Nightblood'>Nightblood</a> mentions <a target='_blank' href='https://coppermind.net/wiki/Denth'>Denth</a>, <a target='_blank' href='https://coppermind.net/wiki/Shashara'>Shashara</a>, and <a target='_blank' href='https://coppermind.net/wiki/Vivenna'>Vivenna</a> by name. A painting from the <a target='_blank' href='https://coppermind.net/wiki/Court_of_Gods'>Court of Gods</a> appears in <a target='_blank' href='https://coppermind.net/wiki/Summary:Oathbringer#Chapter_102:_Celebrant'>Chapter 102</a>. <a target='_blank' href='https://coppermind.net/wiki/Riino'>Riino</a> mentions <a target='_blank' href='https://coppermind.net/wiki/Heightening'>Heightenings</a>. <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> uses <a target='_blank' href='https://coppermind.net/wiki/Awakening'>Awakening</a> in the <a target='_blank' href='https://coppermind.net/wiki/Summary:Oathbringer#Epilogue:_Great_Art'>Epilogue</a>."
-                                },
-								{
-                                    "target": "sa3.5",
-                                    "type": "minor",
-                                    "description": "The <a target='_blank' href='https://coppermind.net/wiki/Dawnshard'>Dawnshard</a> causes <a target='_blank' href='https://coppermind.net/wiki/Rysn_Ftori'>Rysn</a> to experience several effects similar to the <a target='_blank' href='https://coppermind.net/wiki/BioChromatic_Breath'>Heightenings associated with Breath</a>."
-                                },
-								{
-                                    "target": "sa4",
-                                    "type": "major",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Nightblood'>Nightblood</a> is used to kill <a target='_blank' href='https://coppermind.net/wiki/Rayse'>Rayse</a>. <a target='_blank' href='https://coppermind.net/wiki/Ialai'>Ialai's</a> notes mention <a target='_blank' href='https://coppermind.net/wiki/Nalthis'>Nalthis</a>. <a target='_blank' href='https://coppermind.net/wiki/Zahel'>Zahel</a> uses <a target='_blank' href='https://coppermind.net/wiki/Awakening'>Awakening</a> in his fight against <a target='_blank' href='https://coppermind.net/wiki/Kaladin'>Kaladin</a> and explains that he is a <a target='_blank' href='https://coppermind.net/wiki/Cognitive_Shadow'>Cognitive Shadow</a>. The coin <a target='_blank' href='https://coppermind.net/wiki/Adolin'>Adolin</a> gives to <a target='_blank' href='https://coppermind.net/wiki/Kaladin'>Kaladin</a> and some merchants in <a target='_blank' href='https://coppermind.net/wiki/Lasting_Integrity'>Lasting Integrity</a> are from <a target='_blank' href='https://coppermind.net/wiki/Nalthis'>Nalthis</a>. <a target='_blank' href='https://coppermind.net/wiki/Endowment'>Endowment</a> is referenced in the <a target='_blank' href='https://coppermind.net/wiki/Rhythm_of_War/Epigraphs'>Chapter 24 epigraph</a>. <a target='_blank' href='https://coppermind.net/wiki/Odium'>Odium</a> tampers with <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid's</a> <a target='_blank' href='https://coppermind.net/wiki/BioChromatic_Breath'>Breath</a> in the Epilogue."
-                                },
-				{
-				    "target": "mb7",
-				    "type": "significant",
-				    "description": "WIP"
-				}
-                            ]
-                        },
-                        {
-                            "id": "nb",
-                            "title": "Nightblood",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Nightblood_(book)'>Nightblood</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Nalthis'>Nalthis</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Nalthian_system'>Nalthian system</a>",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/87/#e5657'>This sequel occurs prior to The Stormlight Archive.</a>",
-                            "sorting": {
-                                "chronology": 5.2
-                            },
-                            "categories": [ "warbreaker", "plan", "unpublished", "novel" ]
-                        }
-                    ]
-                }
-            ]
-        },
-        {
-            "label": "Roshar",
-            "color": "#2aa1d4",
-            "children": [
-                {
-                    "label": "The Stormlight Archive",
-                    "children": [
-                        {
-                            "id": "sa1",
-                            "title": "The Way of Kings",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Way_of_Kings'>The Way of Kings</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-                            "publication": "August 2010",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/309/#e10273'>Occurs after Mistborn Era 1 and Warbreaker but before Mistborn Era 2.</a>",
-                            "sorting": {
-				"order": 2.41,
-                                "publication": 2010.08,
-                                "chronology": 7.01
-                            },
-                            "appearances": [
-                                {
-                                    "id": "hoid",
-                                    "type": "appearance",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is 'Wit'."
-                                },
-                                {
-                                    "id": "ars",
-                                    "type": "appearance"
-                                }
-                            ],
-                            "categories": [ "stormlight", "phase2", "published", "novel" ]
-                        },
-                        {
-                            "id": "sa2",
-                            "title": "Words of Radiance",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Words_of_Radiance'>Words of Radiance</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-                            "publication": "March 2014",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/309/#e10273'>Occurs after Mistborn Era 1 and Warbreaker but before Mistborn Era 2.</a>",
-                            "sorting": {
-				"order": 2.42,
-                                "publication": 2014.03,
-                                "chronology": 7.02
-                            },
-                            "appearances": [
-                                {
-                                    "id": "hoid",
-                                    "type": "appearance",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is 'Wit'."
-                                },
-                                {
-                                    "id": "nazh",
-                                    "type": "appearance",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> is the <a target='_blank' href='https://coppermind.net/wiki/Ardent'>ardent</a> trying to get a sketch of <a target='_blank' href='https://coppermind.net/wiki/Bridge_Four'>Bridge Four</a>'s tattoo in <a target='_blank' href='https://coppermind.net/wiki/Summary:Words_of_Radiance#Chapter_31:_The_Stillness_Before'>Chapter 31</a>. Several drawings and sketches also include his annotations."
-                                },
-                                {
-                                    "id": "ars",
-                                    "type": "appearance"
-                                }
-                            ],
-                            "categories": [ "stormlight", "phase2", "published", "novel" ],
-                            "connections": [
-                                {
-                                    "target": "jasnah",
-                                    "type": "major",
-                                    "description": "A deleted scene about <a target='_blank' href='https://coppermind.net/wiki/Jasnah_Kholin'>Jasnah</a> that contains some canonical elements."
-                                },
-                                {
-                                    "target": "traveler",
-                                    "type": "minor",
-                                    "description": "The man <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> speaks with is <a target='_blank' href='https://coppermind.net/wiki/Frost'>Frost</a>, who responded to <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> with similar opinions in the <a target='_blank' href='https://coppermind.net/wiki/Words_of_Radiance/Epigraphs#The_Second_Letter'>Words of Radiance Part 4 epigraphs</a>."
-                                },
-                                {
-                                    "target": "au",
-                                    "type": "minor",
-                                    "description": "The <a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a> essay covers details about <a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a> and makes mentions of <a target='_blank' href='https://coppermind.net/wiki/Odium'>Odium</a>'s past."
-                                },
-				{
-				    "target": "mb7",
-				    "type": "minor",
-				    "description": "WIP"
-				}
-                            ]
-                        },
-                        {
-                            "id": "sa2.5",
-                            "title": "Edgedancer",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Edgedancer'>Edgedancer</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-                            "au": "Included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
-                            "padding": 12,
-                            "publication": "November 2016",
-                            "chronology": "Occurs after Words of Radiance and concurrently with the early events of Oathbringer.",
-                            "sorting": {
-				"order": 2.43,
-                                "publication": 2016.11,
-                                "chronology": 7.025
-                            },
-                            "appearances": [
-                                {
-                                    "id": "hoid",
-                                    "type": "mention",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is 'Ol' Whitehair', mentioned in <a target='_blank' href='https://coppermind.net/wiki/Summary:Edgedancer#Chapter_12'>Chapter 12</a>."
-                                }
-                            ],
-                            "categories": [ "stormlight", "novella", "phase2", "published" ]
-                        },
-                        {
-                            "id": "sa3",
-                            "title": "Oathbringer",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Oathbringer'>Oathbringer</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-                            "publication": "November 2017",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/309/#e10273'>Occurs after Mistborn Era 1 and Warbreaker but before Mistborn Era 2.</a>",
-                            "sorting": {
-				"order": 2.44,
-                                "publication": 2017.11,
-                                "chronology": 7.03
-                            },
-                            "appearances": [
-                                {
-                                    "id": "hoid",
-                                    "type": "appearance",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is 'Wit'."
-                                },
-                                {
-                                    "id": "nazh",
-                                    "type": "mention",
-                                    "description": "Several drawings and sketches include <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a>'s annotations. Most notably, the <a target='_blank' href='https://coppermind.net/wiki/Glyphs'>glyphs</a> page is entirely written by him."
-                                },
-                                {
-                                    "id": "ars",
-                                    "type": "appearance"
-                                }
-                            ],
-                            "categories": [ "stormlight", "phase2", "published", "novel" ],
-                            "connections": [
-                                {
-                                    "target": "twokp",
-                                    "type": "minor",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/The_Way_of_Kings_Prime'>The Way of Kings Prime</a>, written in 2002, is the original draft of <a target='_blank' href='https://coppermind.net/wiki/The_Way_of_Kings'>The Way of Kings</a>. Only small excerpts were released prior to <a target='_blank' href='https://coppermind.net/wiki/The_Way_of_Kings'>Oathbringer</a> as Brandon felt it contained spoilers for certain ideas through that book. It was self-published as a Sanderson Curiosity in July 2020."
-                                },
-				{
-				    "target": "mb7",
-				    "type": "minor",
-				    "description": "WIP"
-				}
-                            ]
-                        },
-                        {
-                            "id": "sa3.5",
-                            "title": "Dawnshard",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Dawnshard_(novella)'>Dawnshard</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-                            "publication": "November 2020",
-			    "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/406/#e13986'>Between Oathbringer and Rhythm of War.</a>",
-                            "padding": 12,
-                            "sorting": {
-				"order": 2.45,
-                                "publication": 2020.1105,
-                                "chronology": 7.035
-                            },
-                            "categories": [ "stormlight", "novella", "published", "phase2" ]
-                        },
-                        {
-                            "id": "sa4",
-                            "title": "Rhythm of War",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Rhythm_of_War'>Rhythm of War</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-                            "publication": "November 2020",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/309/#e10273'>Occurs after Mistborn Era 1 and Warbreaker but before Mistborn Era 2.</a>",
-                            "sorting": {
-				"order": 2.46,
-                                "publication": 2020.1117,
-                                "chronology": 7.04
-                            },
-                            "appearances": [
-                                {
-                                    "id": "hoid",
-                                    "type": "appearance",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is 'Wit'."
-                                },
-                                {
-                                    "id": "nazh",
-                                    "type": "mention",
-                                    "description": "Several drawings and sketches include <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a>'s annotations. Most notably, the <a target='_blank' href='https://coppermind.net/wiki/Glyphs'>glyphs</a> page is entirely written by him."
-                                },
-                                {
-                                    "id": "ars",
-                                    "type": "appearance"
-                                }
-                            ],
-                            "categories": [ "stormlight", "novel", "phase2", "published" ],
-                            "connections": [
-                                {
-                                    "target": "d1",
-                                    "type": "egg",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Microkinesis'>Microkinesis</a> referes to a type of magic from <a target='_blank' href='https://coppermind.net/wiki/Yolen'>Yolen</a> in <a target='_blank' href='https://coppermind.net/wiki/Dragonsteel'>Dragonsteel</a>."
-                                },
-                                {
-                                    "target": "mb2",
-                                    "type": "minor",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Ati'>Ati</a> speaks to <a target='_blank' href='https://coppermind.net/wiki/Vin'>Vin</a> and others with <a target='_blank' href='https://coppermind.net/wiki/Ruin'>Ruin's</a> <a target='_blank' href='https://coppermind.net/wiki/Rhythm#The_Pure_Tones'>Pure Tone</a>. The <a target='_blank' href='https://coppermind.net/wiki/Well_of_Ascension'>Well of Ascension</a> pulses with <a target='_blank' href='https://coppermind.net/wiki/Preservation'>Preservation's</a> <a target='_blank' href='https://coppermind.net/wiki/Rhythm#The_Pure_Tones'>Pure Tone</a>"
-                                },
-				{
-				    "target": "mb7",
-				    "type": "significant",
-				    "description": "WIP"
-				}
-                            ]
-                        },
-                        {
-                            "id": "sa4.5",
-                            "title": "Horneater (2023)",
-                            "title2": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2019/'>Horneater</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-                            "padding": 12,
-                            "chronology": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>Fills in what happened with Rock after the events of Rhythm of War.</a>",
-                            "sorting": {
-                                "publication": 2023.11,
-				"chronology": 7.045
-                            },
-                            "categories": [ "stormlight", "novella", "plan", "unpublished" ]
-                        },
-                        {
-                            "id": "sa5",
-                            "title": "Stormlight Archive 5 (2024)",
-                            "title2": "Stormlight Archive 5",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-                            "publication": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>Fall 2023</a>",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/309/#e10273'>Occurs after Mistborn Era 1 and Warbreaker but before Mistborn Era 2.</a>",
-                            "sorting": {
-				"publication": 2023.11,
-                                "chronology": 7.05
-                            },
-                            "categories": [ "stormlight", "plan", "forthcoming", "novel" ]
-                        },
-                        {
-                            "id": "lopen",
-                            "title": "King Lopen the First",
-                            "title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=king+lopen+the+first+of+alethkar'>King Lopen the First of Alethkar</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/31/#e1703'>Occurs concurrently with the final events of Words of Radiance.</a>",
-                            "padding": 12,
-                            "sorting": {
-                                "chronology": 7.022
-                            },
-                            "categories": [ "stormlight", "short", "plan", "unpublished" ]
-                        },
-                        {
-                            "id": "tdatd",
-                            "title": "The Dog and the Dragon",
-                            "title2": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>The Dog and the Dragon picture book</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-                            "padding": 12,
-                            "categories": [ "stormlight", "plan", "unpublished", "graphic" ]
-                        },
-                        {
-                            "id": "tgwlu",
-                            "title": "The Girl Who Looked Up",
-                            "title2": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>The Girl Who Looked Up picture book</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-                            "padding": 12,
-                            "categories": [ "stormlight", "plan", "unpublished", "graphic" ]
-                        },
-                        {
-                            "id": "sa-art",
-                            "title": "Stormlight Archive art book",
-                            "title2": "<a target='_blank' href='https://wob.coppermind.net/events/396/#e13175'>Stormlight Archive art book</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-                            "padding": 12,
-                            "categories": [ "stormlight", "plan", "unpublished", "graphic" ]
-                        },
-                        {
-                            "id": "sa6",
-                            "title": "Stormlight Archive 6",
-                            "title2": "Stormlight Archive 6",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/61/#e1300'>There's a roughly 15 year gap between Stormlight 5 and 6.</a> <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>Occurs after Mistborn Era 2 and before Mistborn Era 3.</a>",
-                            "publication": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>2028 (best guess)</a>",
-                            "sorting": {
-                                "chronology": 9.06,
-				"publication": 2028
-                            },
-                            "categories": [ "stormlight", "plan", "unpublished", "novel" ]
-                        },
-                        {
-                            "id": "sa7",
-                            "title": "Stormlight Archive 7",
-                            "title2": "Stormlight Archive 7",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/61/#e1300'>There's a roughly 15 year gap between Stormlight 5 and 6.</a> <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>Occurs after Mistborn Era 2 and before Mistborn Era 3.</a>",
-                            "sorting": {
-                                "chronology": 9.07
-                            },
-                            "categories": [ "stormlight", "plan", "unpublished", "novel" ]
-                        },
-                        {
-                            "id": "sa8",
-                            "title": "Stormlight Archive 8",
-                            "title2": "Stormlight Archive 8",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/61/#e1300'>There's a roughly 15 year gap between Stormlight 5 and 6.</a> <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>Occurs after Mistborn Era 2 and before Mistborn Era 3.</a>",
-                            "sorting": {
-                                "chronology": 9.08
-                            },
-                            "categories": [ "stormlight", "plan", "unpublished", "novel" ]
-                        },
-                        {
-                            "id": "sa9",
-                            "title": "Stormlight Archive 9",
-                            "title2": "Stormlight Archive 9",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/61/#e1300'>There's a roughly 15 year gap between Stormlight 5 and 6.</a> <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>Occurs after Mistborn Era 2 and before Mistborn Era 3.</a>",
-                            "sorting": {
-                                "chronology": 9.09
-                            },
-                            "categories": [ "stormlight", "plan", "unpublished", "novel" ]
-                        },
-                        {
-                            "id": "sa10",
-                            "title": "Stormlight Archive 10",
-                            "title2": "Stormlight Archive 10",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/61/#e1300'>There's a roughly 15 year gap between Stormlight 5 and 6.</a> <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>Occurs after Mistborn Era 2 and before Mistborn Era 3.</a>",
-                            "sorting": {
-                                "chronology": 9.10
-                            },
-                            "categories": [ "stormlight", "plan", "unpublished", "novel" ],
-                            "connections": [
-                                {
-                                    "target": "sotd2",
-                                    "type": "minor",
-                                    "description": "A <a target='_blank' href='https://coppermind.net/wiki/Knights_Radiant'>Knight Radiant</a> makes an appearance, weilding a 'Shardgun'."
-                                }
-                            ]
-                        }
-                    ]
-                },
-				{
-					"children": [
-                        {
-                            "id": "tsd",
-                            "title": "The Silence Divine",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Silence_Divine'>The Silence Divine</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Ashyn'>Ashyn</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-                            "link": "<a target='_blank' href='https://wob.coppermind.net/events/201/#e12303'>Excerpt on Arcanum.</a>",
-                            "publication": "March 2014",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/370/#e11901'>Occurs late in the Stormlight Archive era, around book 8.</a>",
-                            "sorting": {
-                                "publication": 2014.03,
-                                "chronology": 9.081
-                            },
-                            "categories": [ "no-series", "plan", "unpublished", "novella" ],
-                            "connections": [
-                                {
-                                    "target": "sa3",
-                                    "type": "minor",
-                                    "description": "The Silence Divine is set on <a target='_blank' href='https://coppermind.net/wiki/Ashyn'>Ashyn</a>, the world that the humans fled to <a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a> from."
-                                }
-                            ]
-                        }
-		    ]
-		}
-            ]
-        },
-        {
-            "label": "Taldain",
-            "color": "#d4c955",
-            "children": [
-                {
-                    "label": "White Sand",
-                    "children": [
-                        {
-                            "id": "ws1",
-                            "title": "White Sand Volume 1",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/White_Sand_Volume_1'>White Sand Volume 1</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/White_Sand'>White Sand</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Taldain_system'>Taldain system</a>",
-                            "au": "Excerpt included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
-                            "publication": "June 2016",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/182/#e3878'>White Sand occurs prior to Elantris.</a>",
-                            "sorting": {
-				"order": 2.11,
-                                "publication": 2016.06,
-                                "chronology": 2.1
-                            },
-                            "appearances": [
-                                {
-                                    "id": "hoid",
-                                    "type": "appearance",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is the hooded man with a stringed instrument who first appears in <a target='_blank' href='https://coppermind.net/wiki/Ais'>Ais</a>'s first scene in the middle of <a target='_blank' href='https://coppermind.net/wiki/Summary:White_Sand_Volume_1#Chapter_4:_Divides'>Chapter 4</a>."
-                                },
-                                {
-                                    "id": "khriss",
-                                    "type": "appearance",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> is a main character."
-                                }
-                            ],
-                            "categories": [ "white-sand", "phase2b", "published", "graphic" ],
-                            "connections": [
-                                {
-                                    "target": "mb1",
-                                    "type": "egg",
-                                    "description": "'Kenton Street' in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Well_of_Ascension#Chapter_17'>Chapter 17</a> (also mentioned in <a target='_blank' href='https://coppermind.net/wiki/The_Well_of_Ascension'>The Well of Ascension) is a reference to <a target='_blank' href='https://coppermind.net/wiki/Kenton'>Kenton</a>."
-                                },
-                                {
-                                    "target": "sa2",
-                                    "type": "egg",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Mraize'>Mraize</a>'s collection in <a target='_blank' href='https://coppermind.net/wiki/Summary:Words_of_Radiance#Chapter_43:_The_Ghostbloods'>Chapter 43</a> includes a vial of sand from <a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a>."
-                                },
-                                {
-                                    "target": "au",
-                                    "type": "minor",
-                                    "description": "The <a target='_blank' href='https://coppermind.net/wiki/Taldain_system'>Taldain system</a> essay discusses <a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a> and <a target='_blank' href='https://coppermind.net/wiki/Sand_mastery'>sand mastery</a>."
-                                },
-                                {
-                                    "target": "sa4",
-                                    "type": "minor",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a> is referenced in <a target='_blank' href='https://coppermind.net/wiki/Ialai'>Ialai's</a> notes."
-                                },
-				{
-				    "target": "mb7",
-				    "type": "minor",
-				    "description": "WIP"
-				}
-                            ]
-                        },
-                        {
-                            "id": "ws2",
-                            "title": "White Sand Volume 2",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/White_Sand_Volume 2'>White Sand Volume 2</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/White_Sand'>White Sand</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Taldain_system'>Taldain system</a>",
-                            "publication": "February 2018",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/182/#e3878'>White Sand occurs prior to Elantris.</a>",
-                            "sorting": {
-				"order": 2.12,
-                                "publication": 2018.02,
-                                "chronology": 2.2
-                            },
-                            "appearances": [
-                                {
-                                    "id": "hoid",
-                                    "type": "appearance",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is the hooded man with a stringed instrument."
-                                },
-                                {
-                                    "id": "khriss",
-                                    "type": "appearance",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> is a main character."
-                                }
-                            ],
-                            "categories": [ "white-sand", "phase2b", "published", "graphic" ],
-                            "connections": [
-                                {
-                                    "target": "mb1",
-                                    "type": "minor",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Trell_(Taldain)'>Trell the foreman</a> is connected to <a target='_blank' href='https://coppermind.net/wiki/Trelagism'>Trelagism</a>."
-                                },
-                                {
-                                    "target": "mb4",
-                                    "type": "significant",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Trell_(Taldain)'>Trell the foreman</a> is connected to the god <a target='_blank' href='https://coppermind.net/wiki/Trellism'>Trell</a>."
-                                },
-                                {
-                                    "target": "sa3",
-                                    "type": "egg",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Wit</a> has a jar of black sand from <a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a> in <a target='_blank' href='https://coppermind.net/wiki/Summary:Oathbringer#Chapter_67:_Mishim'>Chapter 67</a>, which turns white after <a target='_blank' href='https://coppermind.net/wiki/Shallan'>Shallan</a> <a target='_blank' href='https://coppermind.net/wiki/Lightweaving'>Lightweaves</a>."
-                                },
-                                {
-                                    "target": "sa4",
-                                    "type": "minor",
-                                    "description": "Sand from <a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a> is used to identify and quantify <a target='_blank' href='https://coppermind.net/wiki/Investiture'>kinetic Investiture</a>, including explicit mention of the fauna which makes the sand special."
-                                }
-                            ]
-                        },
-                        {
-                            "id": "ws3",
-                            "title": "White Sand Volume 3",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/White_Sand_Volume_3'>White Sand Volume 3</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/White_Sand'>White Sand</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Taldain_system'>Taldain system</a>",
-                            "publication": "October 2019",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/182/#e3878'>White Sand occurs prior to Elantris.</a>",
-                            "sorting": {
-				"order": 2.13,
-                                "publication": 2019.10,
-                                "chronology": 2.3
-                            },
-                            "appearances": [
-                                {
-                                    "id": "hoid",
-                                    "type": "appearance",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is the hooded man with a stringed instrument who plays a song in the <a target='_blank' href='https://coppermind.net/wiki/Summary:White_Sand_Volume_3#Epilogue'>Epilogue</a>."
-                                },
-                                {
-                                    "id": "khriss",
-                                    "type": "appearance",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> is a main character."
-                                }
-                            ],
-                            "categories": [ "white-sand", "phase2b", "published", "graphic" ],
-                            "connections": [
-                                {
-                                    "target": "sa1",
-                                    "type": "egg",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Baon'>Baon</a> appears in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Way_of_Kings#Interlude_I-1:_Ishikk'>Interlude I-1</a> as 'Blunt'."
-                                }
-                            ]
-                        }
-                    ]
-                },
+	"base-separation": 3.21,
+	"connections": [
 		{
-                    "label": "The Arcanist",
-                    "children": [
-                        {
-                            "id": "ta1",
-                            "title": "The Arcanist Volume 1",
-                            "title2": "The Arcanist Volume 1",
-                            "series": "The Arcanist (citation needed)",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Taldain_system'>Taldain system</a>",
-                            "chronology": "Described as a sequel, so presumably occurs shortly after White Sand.",
-                            "sorting": {
-                                "chronology": 2.5
-                            },
-                            "categories": [ "white-sand", "plan", "unpublished", "graphic" ]
-                        },
-                        {
-                            "id": "ta2",
-                            "title": "The Arcanist Volume 2",
-                            "title2": "The Arcanist Volume 2",
-                            "series": "The Arcanist (citation needed)",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Taldain_system'>Taldain system</a>",
-                            "chronology": "Described as a sequel, so presumably occurs shortly after White Sand.",
-                            "sorting": {
-                                "chronology": 2.6
-                            },
-                            "categories": [ "white-sand", "plan", "unpublished", "graphic" ]
-                        },
-                        {
-                            "id": "ta3",
-                            "title": "The Arcanist Volume 3",
-                            "title2": "The Arcanist Volume 3",
-                            "series": "The Arcanist (citation needed)",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Taldain_system'>Taldain system</a>",
-                            "chronology": "Described as a sequel, so presumably occurs shortly after White Sand.",
-                            "sorting": {
-                                "chronology": 2.7
-                            },
-                            "categories": [ "white-sand", "plan", "unpublished", "graphic" ]
-                        }
-                    ]
-                }
-            ]
-        },
-        {
-            "label": "Threnody",
-            "color": "#6633cc",
-            "children": [
-                {
-                    "children": [
-                        {
-                            "id": "sfs",
-                            "title": "Shadows for Silence",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Shadows_for_Silence_in_the_Forests_of_Hell'>Shadows for Silence in the Forests of Hell</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Threnody'>Threnody</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Threnodite_system'>Threnodite system</a>",
-                            "au": "Included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
-                            "publication": "December 2013",
-                            "chronology": "Occurs <a target='_blank' href='https://wob.coppermind.net/events/216/#e6445'>before Stormlight Archive</a> but <a target='_blank' href='https://wob.coppermind.net/events/309/#e10273'>after Warbreaker</a>.",
-                            "sorting": {
-				"order": 1.5,
-                                "publication": 2013.12,
-                                "chronology": 6.1
-                            },
-                            "categories": [ "no-series", "novella", "phase1b", "published" ],
-                            "connections": [
-                                {
-                                    "target": "sa2",
-                                    "type": "egg",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Mraize'>Mraize</a>'s collection in <a target='_blank' href='https://coppermind.net/wiki/Summary:Words_of_Radiance#Chapter_43:_The_Ghostbloods'>Chapter 43</a> includes a silver knife from <a target='_blank' href='https://coppermind.net/wiki/Threnody'>Threnody</a>."
-                                },
-                                {
-                                    "target": "sa3",
-                                    "type": "egg",
-                                    "description": "The silvery chain in <a target='_blank' href='https://coppermind.net/wiki/Celebrant'>Celebrant</a> is from <a target='_blank' href='https://coppermind.net/wiki/Threnody'>Threnody</a>."
-                                },
-                                {
-                                    "target": "msh",
-                                    "type": "minor",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Kelsier'>Kelsier</a> causes the <a target='_blank' href='https://coppermind.net/wiki/Ire'>Ire</a> to suspect <a target='_blank' href='https://coppermind.net/wiki/Shade'>Shades</a> from <a target='_blank' href='https://coppermind.net/wiki/Threnody'>Threnody</a> are nearby."
-                                },
-                                {
-                                    "target": "au",
-                                    "type": "minor",
-                                    "description": "The <a target='_blank' href='https://coppermind.net/wiki/Threnodite_system'>Threnodite system</a> essay discusses the history of <a target='_blank' href='https://coppermind.net/wiki/Threnody'>Threnody</a>."
-                                },
-                                {
-                                    "target": "sa4",
-                                    "type": "egg",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Raboniel'>Raboniel's</a> chain from 'the lands of the dead' is likely a <a target='_blank' href='https://coppermind.net/wiki/Silver'>silver</a> chain from <a target='_blank' href='https://coppermind.net/wiki/Threnody'>Threnody</a>."
-                                }
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "children": [
-                        {
-                            "id": "db",
-                            "title": "The Dust Brigade",
-                            "title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=the+dust+brigade'>The Dust Brigade</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Threnody'>Threnody</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Threnodite_system'>Threnodite system</a>",
-                            "categories": [ "no-series", "plan", "unpublished", "novel" ]
-                        }
-                    ]
-                }
-            ]
-        },
-        {
-            "label": "First of<br>the Sun",
-            "color": "#367485",
-            "children": [
-                {
-                    "children": [
-                        {
-                            "id": "sotd",
-                            "title": "Sixth of the Dusk",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Sixth_of_the_Dusk'>Sixth of the Dusk</a>",
-                            "series": "Sixth of<br>the Dusk",
-							"world": "<a target='_blank' href='https://coppermind.net/wiki/First_of_the_Sun'>First of the Sun</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Drominad_system'>Drominad system</a>",
-                            "au": "Included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
-                            "publication": "June 2014",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/60/#e6664'>Shortly before Mistborn Era 4.</a>",
-                            "sorting": {
-				"order": 1.6,
-                                "publication": 2014.06,
-                                "chronology": 13.0
-                            },
-                            "categories": [ "no-series", "novella", "phase1b", "published" ],
-                            "connections": [
-                                {
-                                    "target": "sa3",
-                                    "type": "minor",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Mraize'>Mraize</a>'s chicken, mentioned in <a target='_blank' href='https://coppermind.net/wiki/Summary:Oathbringer#Chapter_22:_The_Darkness_Within'>Chapter 22</a>, is an <a target='_blank' href='https://coppermind.net/wiki/Aviar'>Aviar</a>. <a target='_blank' href='https://coppermind.net/wiki/Patji'>Patji</a> is referenced obliquely in <a target='_blank' href='https://coppermind.net/wiki/Autonomy'>Autonomy</a>'s <a target='_blank' href='https://coppermind.net/wiki/Letters#Second_Oathbringer_Letter'>letter</a> to <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> in the <a target='_blank' href='https://coppermind.net/wiki/Oathbringer/Epigraphs#Letters'>Part 2 epigraphs</a>."
-                                },
-                                {
-                                    "target": "au",
-                                    "type": "minor",
-                                    "description": "The <a target='_blank' href='https://coppermind.net/wiki/Drominad_system'>Drominad system</a> essay discusses <a target='_blank' href='https://coppermind.net/wiki/First_of_the_Sun'>First of the Sun</a> and its magic."
-                                },
-                                {
-                                    "target": "sa4",
-                                    "type": "minor",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Gereh'>Gereh</a> has an <a target='_blank' href='https://coppermind.net/wiki/Aviar'>Aviar</a>, which <a target='_blank' href='https://coppermind.net/wiki/Lift'>Lift</a> comes into possession of."
-                                }
-                            ]
-                        },
-                        {
-                            "id": "sotd2",
-                            "title": "Sixth of the Dusk sequel",
-                            "title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=sixth+of+the+dusk+sequel'>Sixth of the Dusk sequel</a>",
-                            "series": "Sixth of<br>the Dusk",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/First_of_the_Sun'>First of the Sun</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Drominad_system'>Drominad system</a>",
-                            "chronology": "Five years after Sixth of the Dusk.",
-                            "sorting": {
-                                "chronology": 13.02
-                            },
-                            "link": "<a target='_blank' href='https://wob.coppermind.net/events/448/#e14408'>Excerpt on Arcanum.</a> (some may consider to be spoilers)",
-                            "categories": [ "no-series", "novella", "plan", "unpublished" ]
-                        }
-                    ]
-                },
-                {
-                    "children": [
-                        {
-                            "id": "kingmaker",
-                            "title": "Kingmaker",
-                            "title2": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>Kingmaker</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/First_of_the_Sun'>First of the Sun</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Drominad_system'>Drominad system</a>",
-                            "link": "<a target='_blank' href='https://wob.coppermind.net/events/479/#e15153'>Reading on Arcanum.</a>",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/479/#e15153'>The reading suggests a setting not long after Sixth of the Dusk.</a>",
-                            "sorting": {
-                                "chronology": 13.01
-                            },
-                            "categories": [ "no-series", "novel", "plan", "unpublished" ]
-                        }
-				    ]
-                }
-            ]
-        },
-        {
-            "label": "Yolen",
-            "color": "#d98a41",
-            "children": [
-                {
-                    "label": "Dragonsteel",
-                    "children": [
-                        {
-                            "id": "d1",
-                            "title": "Dragonsteel 1",
-                            "title2": "Dragonsteel 1",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Dragonsteel'>Dragonsteel</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Yolen'>Yolen</a>",
-                            "system": "Yolish system",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/103/#e1024'>Dragonsteel is the first series in the cosmere storyline.</a>",
-                            "sorting": {
-                                "chronology": 1.1
-                            },
-                            "categories": [ "dragonsteel", "plan", "unpublished", "novel" ],
-			    "connections": [
+			"id": "major",
+			"description": "Major Connections",
+			"details": "There is at least one major connection between the books which will enhance your understanding of the plot and the Cosmere. Reading in this order is highly recommended, and reading out of order may be spoilery.",
+			"color": "#770000",
+			"highlightColor": "#DB1E1E",
+			"width": 2
+		},
+		{
+			"id": "significant",
+			"description": "Significant Connections",
+			"details": "There is at least one significant connection between the books which may enhance your understanding of the plot and the Cosmere. Reading in this order is recommended.",
+			"color": "#a0470d",
+			"highlightColor": "#a0470d",
+			"width": 2,
+			"dash": "4 2"
+		},
+		{
+			"id": "minor",
+			"description": "Minor Connections",
+			"details": "There is at least one minor connection between the books which may enhance your understanding of the plot and Cosmere in a small way.",
+			"color": "#a09713",
+			"highlightColor": "#a09713",
+			"width": 1,
+			"dash": "3",
+			"activeByDefault": false
+		},
+		{
+			"id": "egg",
+			"description": "Easter Eggs",
+			"details": "There is at least one subtle reference between the books which may hint at something bigger going on. Easter eggs may be very difficult to spot unaided.",
+			"color": "#4d4d4d",
+			"highlightColor": "#4d4d4d",
+			"width": 1,
+			"dash": "2",
+			"activeByDefault": false
+		}
+	],
+	"layers": [
+		{
+			"id": "pub-status",
+			"name": "Publication Status",
+			"categories": [
 				{
-				    "target": "mb7",
-				    "type": "egg",
-				    "description": "WIP"
+					"id": "published",
+					"description": "Published",
+					"details": "Published, canonical works.",
+					"color": "#FFFFFF"
+				},
+				{
+					"id": "forthcoming",
+					"description": "Forthcoming",
+					"details": "Forthcoming works with a planned release month or which are being actively worked on. Expected publication dates may be in parenthesis. Titles may be tentative.",
+					"color": "#888888"
+				},
+				{
+					"id": "unpublished",
+					"description": "Future Plans",
+					"details": "Includes all planned future cosmere stories. Likelihood of publication varies. Expected publication dates may be in parenthesis. Titles are tentative.",
+					"color": "#505050"
+				},
+				{
+					"id": "noncanon",
+					"description": "Other",
+					"details": "Uncanonical works which are publicly available, both excerpts and complete.",
+					"color": "#735a45"
 				}
 			]
-                        },
-                        {
-                            "id": "d2",
-                            "title": "Dragonsteel 2",
-                            "title2": "Dragonsteel 2",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Dragonsteel'>Dragonsteel</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Yolen'>Yolen</a>",
-                            "system": "Yolish system",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/103/#e1024'>Dragonsteel is the first series in the cosmere storyline.</a>",
-                            "sorting": {
-                                "chronology": 1.2
-                            },
-                            "categories": [ "dragonsteel", "plan", "unpublished", "novel" ]
-                        },
-                        {
-                            "id": "d3",
-                            "title": "Dragonsteel 3",
-                            "title2": "Dragonsteel 3",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/Dragonsteel'>Dragonsteel</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Yolen'>Yolen</a>",
-                            "system": "Yolish system",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/103/#e1024'>Dragonsteel is the first series in the cosmere storyline.</a>",
-                            "sorting": {
-                                "chronology": 1.3
-                            },
-                            "categories": [ "dragonsteel", "plan", "unpublished", "novel" ]
-                        }
-                    ]
-                }
-            ]
-        },
-        {
-            "label": "Other",
-            "color": "#a0a0a0",
-            "children": [
-                {
-                    "label": "Aether<br>Series",
-		    "color": "#e3a1e3",
-		    "children": [
-                        {
-                            "id": "aether1",
-                            "title": "Aether Book 1",
-                            "title2": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2019/'>Aether Book 1</a>",
-                            "world": "Unknown",
-                            "system": "Unknown",
-                            "categories": [ "aether", "novel", "plan", "unpublished" ]
-                        },
-                        {
-                            "id": "aether2",
-                            "title": "Aether Book 2",
-                            "title2": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2019/'>Aether Book 2</a>",
-                            "world": "Unknown",
-                            "system": "Unknown",
-                            "categories": [ "aether", "novel", "plan", "unpublished" ]
-                        },
-                        {
-                            "id": "aether3",
-                            "title": "Aether Book 3",
-                            "title2": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2019/'>Aether Book 3</a>",
-                            "world": "Unknown",
-                            "system": "Unknown",
-                            "categories": [ "aether", "novel", "plan", "unpublished" ]
-                        }
-                    ]
-                },
-                {
-                    "children": [
-                        {
-                            "id": "secret1",
-                            "title": "Secret Project 1 (2023)",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Secret_Project_One'>Secret Project 1</a>",
-                            "world": "Spoiler",
-                            "system": "Spoiler",
-                            "publication": "January 2023",
-                            "sorting": {
-                                "publication": 2023.01
-                            },
-                            "link": "Chapters 1-5 available on <a target='_blank' href='brandonsanderson.com/first-look-at-secret-project-1'>Brandon's website</a> and <a target='_blank' href='https://youtu.be/bBUVXcIE0E0'>YouTube</a>. (some may consider to be spoilers)",
-                            "categories": [ "no-series", "novel", "plan", "forthcoming" ]
-                        }
-                    ]
-                },
-                {
-                    "children": [
-                        {
-                            "id": "secret3",
-                            "title": "Secret Project 3 (2023)",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Secret_Project_Three'>Secret Project 3</a>",
-                            "world": "Spoiler",
-                            "system": "Spoiler",
-                            "publication": "July 2023",
-                            "sorting": {
-                                "publication": 2023.07
-                            },
-                            "link": "Chapters 1-7 available on <a target='_blank' href='brandonsanderson.com/first-look-at-secret-project-3'>Brandon's website</a> and <a target='_blank' href='https://youtu.be/cFGDcvtRdz0'>YouTube</a>. (some may consider to be spoilers)",
-                            "categories": [ "no-series", "novel", "plan", "forthcoming" ]
-                        }
-                    ]
-                },
-                {
-                    "children": [
-                        {
-                            "id": "secret4",
-                            "title": "Secret Project 4 (2023)",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Secret_Project_Four'>Secret Project 4</a>",
-                            "world": "Spoiler",
-                            "system": "Spoiler",
-                            "publication": "October 2023",
-                            "sorting": {
-                                "publication": 2023.10
-                            },
-                            "categories": [ "no-series", "novel", "plan", "forthcoming" ]
-                        }
-                    ]
-                },
-                {
-                    "children": [
-                        {
-                            "id": "silverlight",
-                            "title": "Silverlight novella",
-                            "title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=silverlight+novella'>Silverlight novella</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Cognitive_Realm'>Cognitive Realm</a>",
-                            "system": "N/A",
-                            "categories": [ "no-series", "novella", "plan", "unpublished" ]
-                        }
-                    ]
-                },
-                {
-                    "children": [
-                        {
-                            "id": "kite",
-                            "title": "Magic Kites YA story",
-                            "title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=kite+magic'>Kite-based magic story</a>",
-                            "world": "Unknown",
-                            "system": "Unknown",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/379/#e12466'>Planned to take place between Mistborn Era 3 and 4.</a>",
-                            "sorting": {
-                                "chronology": 11.0
-                            },
-                            "categories": [ "no-series", "novella", "plan", "unpublished" ]
-                        }
-                    ]
-                },
-                {
-                    "children": [
-                        {
-                            "id": "au",
-                            "title": "Arcanum Unbounded (essays)",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded (essays)</a>",
-                            "world": "N/A",
-                            "system": "N/A",
-                            "au": "Included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
-                            "publication": "November 2016",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/36/#e1491'>The essays were written before the events of Sixth of the Dusk.</a> They could potentially be as early as Mistborn Era 3.",
-                            "sorting": {
-				"order": 2.3,
-                                "publication": 2016.11,
-                                "chronology": 12.0
-                            },
-                            "appearances": [
-                                {
-                                    "id": "khriss",
-                                    "type": "mention",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> is the author of the essays."
-                                }
-                            ],
-                            "categories": [ "no-series", "short", "phase2", "published" ],
-                            "connections": [
-                                {
-                                    "target": "sa4",
-                                    "type": "minor",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Devotion'>Devotion</a> and <a target='_blank' href='https://coppermind.net/wiki/Dominion'>Dominion</a> are referenced in the <a target='_blank' href='https://coppermind.net/wiki/Rhythm_of_War/Epigraphs'>Chapter 26 Epigraph</a>. <a target='_blank' href='https://coppermind.net/wiki/Ambition'>Ambition's</a> struggle with <a target='_blank' href='https://coppermind.net/wiki/Odium'>Odium</a> is referenced in the <a target='_blank' href='https://coppermind.net/wiki/Rhythm_of_War/Epigraphs'>Chapter 27 Epigraph</a>."
-                                },
+		},
+		{
+			"id": "series",
+			"name": "Series",
+			"startActive": true,
+			"categories": [
 				{
-				    "target": "mb7",
-				    "type": "minor",
-				    "description": "WIP"
-				}
-                            ]
-                        }
-                    ]
-                }
-            ]
-        },
-        {
-            "label": "Mixed",
-            "color": "#a0a0a0",
-            "children": [
-                {
-                    "children": [
-                        {
-                            "id": "wsp",
-                            "title": "White Sand (prose)",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/White_Sand_(prose)'>White Sand (prose)</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Taldain_system'>Taldain system</a>",
-                            "au": "Excerpt included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded.</a>.",
-                            "link": "<a target='_blank' href='https://brandonsanderson.com/newsletter-signup/'>Link to full text found in Brandon's newsletter.</a>",
-                            "publication": "June 2009 (upon request)",
-                            "chronology": "<a target='_blank' href='https://wob.coppermind.net/events/182/#e3878'>White Sand occurs prior to Elantris.</a>",
-                            "sorting": {
-                                "order": 2.14,
-                                "publication": 2009.06,
-                                "chronology": 2.0
-                            },
-                            "appearances": [
-                                {
-                                    "id": "khriss",
-                                    "type": "appearance",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> is a main character."
-                                }
-                            ],
-                            "categories": [ "white-sand", "novel", "apocryphal", "noncanon" ],
-                            "connections": [
-                                {
-                                    "target": "ws1",
-                                    "type": "minor",
-                                    "description": "The <a target='_blank' href='https://coppermind.net/wiki/White_Sand'>White Sand</a> graphic novels are based on the prose version."
-                                }
-                            ]
-                        },
-                        {
-                            "id": "aon",
-                            "title": "Aether of Night",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/Aether_of_Night'>Aether of Night</a>",
-                            "world": "Unknown",
-                            "system": "Unknown",
-                            "link": "<a target='_blank' href='https://www.17thshard.com/forum/topic/60219-aether-of-night-manuscript-requests/'>Full text available from the 17th Shard.</a>",
-                            "publication": "June 2009 (upon request)",
-                            "sorting": {
-				                "order": 2.92,
-                                "publication": 2009.06
-                            },
-                            "categories": [ "no-series", "apocryphal", "noncanon", "novel" ],
-                            "connections": [
-                                {
-                                    "target": "sa2",
-                                    "type": "egg",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Mraize'>Mraize</a>'s collection in <a target='_blank' href='https://coppermind.net/wiki/Summary:Words_of_Radiance#Chapter_43:_The_Ghostbloods'>Chapter 43</a> includes pink <a target='_blank' href='https://coppermind.net/wiki/Aether'>aether</a>."
-                                },
-                                {
-                                    "target": "sa3",
-                                    "type": "egg",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Mraize'>Mraize</a> mentions his suit was stained with <a target='_blank' href='https://coppermind.net/wiki/Aether'>aether</a>."
-                                },
-                                {
-                                    "target": "sa4",
-                                    "type": "egg",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Foil'>Foil</a> is said to be seeking 'control over the <a target='_blank' href='https://coppermind.net/wiki/Aether'>aethers</a>'."
-                                },
+					"id": "elantris",
+					"description": "Elantris",
+					"details": "Elantris and its sequels.",
+					"color": "#58b06e"
+				},
 				{
-				    "target": "mb7",
-				    "type": "minor",
-				    "description": "WIP"
-				}
-                            ]
-                        },
-                        {
-                            "id": "imperial-fool",
-                            "title": "Imperial Fool",
-                            "title2": "Imperial Fool",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Sel'>Sel</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Selish_system'>Selish system</a>",
-                            "link": "<a target='_blank' href='https://brandonsanderson.com/the-emperors-soul-deleted-prologue-imperial-fool'>Full text on Brandon's website.</a>",
-                            "publication": "November 2012",
-                            "chronology": "Concerns events shortly before the events of The Emperor's Soul.",
-                            "sorting": {
-				                "order": 1.41,
-                                "publication": 2012.11,
-                                "chronology": 3.4
-                            },
-                            "appearances": [
-                                {
-                                    "id": "hoid",
-                                    "type": "appearance",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is the 'Imperial Fool'."
-                                }
-                            ],
-                            "categories": [ "no-series", "short", "apocryphal", "noncanon" ],
-			    "connections":[
+					"id": "mistborn",
+					"description": "Mistborn",
+					"details": "Mistborn (all eras)",
+					"color": "#9973bf"
+				},
 				{
-				    "target": "mb7",
-				    "type": "egg",
-				    "description": "WIP"
+					"id": "warbreaker",
+					"description": "Warbreaker",
+					"details": "Warbreaker and its sequel.",
+					"color": "#de4343"
+				},
+				{
+					"id": "stormlight",
+					"description": "Stormlight Archive",
+					"details": "The Stormlight Archive",
+					"color": "#2aa1d4"
+				},
+				{
+					"id": "white-sand",
+					"description": "White Sand",
+					"details": "White Sand and its sequels.",
+					"color": "#d4c955"
+				},
+				{
+					"id": "dragonsteel",
+					"description": "Dragonsteel",
+					"details": "Dragonsteel",
+					"color": "#d98a41"
+				},
+				{
+					"id": "aether",
+					"description": "Aether",
+					"details": "Aether series",
+					"color": "#e3a1e3"
+				},
+				{
+					"id": "no-series",
+					"description": "Non-series Stories",
+					"details": "Stories not part of a series.",
+					"color": "#A0A0A0"
 				}
-			    ]
-                        },
-                        {
-                            "id": "twokp",
-                            "title": "The Way of Kings Prime",
-                            "title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Way_of_Kings_Prime'>The Way of Kings Prime</a>",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-                            "link": "<a target='_blank' href='https://www.brandonsanderson.com/the-way-of-kings-prime/'>Full novel on Brandon's website.</a>",
-                            "publication": "July 2020",
-                            "sorting": {
-				                "order": 2.91,
-                                "publication": 2020.07
-                            },
-                            "categories": [ "stormlight", "novel", "apocryphal", "noncanon" ]
-                        },
-                        {
-                            "id": "jasnah",
-                            "title": "Jasnah deleted scene",
-                            "title2": "Jasnah deleted scene",
-                            "series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
-                            "system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
-                            "link": "<a target='_blank' href='https://www.tor.com/2014/08/06/stormlight-archive-scene-after-words-of-radiance'>Full text on Tor.com.</a>",
-                            "publication": "August 2014",
-                            "chronology": "Occurs during the early events of Words of Radiance.",
-                            "sorting": {
-				                "order": 2.421,
-                                "publication": 2014.08,
-                                "chronology": 7.021
-                            },
-                            "categories": [ "stormlight", "short", "apocryphal", "noncanon" ]
-                        },
-                        {
-                            "id": "traveler",
-                            "title": "The Traveler",
-                            "title2": "The Traveler",
-                            "world": "<a target='_blank' href='https://coppermind.net/wiki/Yolen'>Yolen</a>",
-                            "system": "Yolish system",
-                            "link": "<a target='_blank' href='https://wob.coppermind.net/events/332/#e9518'>Full text on Arcanum.</a>",
-                            "publication": "April 2018",
-                            "chronology": "Occurs shortly after Mistborn Era 1.",
-                            "sorting": {
-                                "order": 2.26,
-                                "publication": 2018.04,
-                                "chronology": 4.5
-                            },
-                            "appearances": [
-                                {
-                                    "id": "hoid",
-                                    "type": "appearance",
-                                    "description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is 'the Traveler'."
-                                }
-                            ],
-                            "categories": [ "no-series", "short", "apocryphal", "noncanon" ]
-                        }
-                    ]
-                }
-            ]
-        }
-    ]
+			]
+		},
+		{
+			"id": "reading-order",
+			"name": "Reading Order",
+			"categories": [
+				{
+					"id": "phase1",
+					"description": "Phase 1 - Essential",
+					"details": "Essential Phase 1 stories should be read before moving to Phase 2.",
+					"color": "#00b02b"
+				},
+				{
+					"id": "phase1b",
+					"description": "Phase 1 - Secondary",
+					"details": "Secondary Phase 1 stories may be read during Phase 1 or anytime after.",
+					"color": "#7bb088"
+				},
+				{
+					"id": "phase2",
+					"description": "Phase 2 - Essential",
+					"details": "Essential Phase 2 stories should be read after all essential Phase 1 works and before moving to Phase 3.",
+					"color": "#0094d4"
+				},
+				{
+					"id": "phase2b",
+					"description": "Phase 2 - Secondary",
+					"details": "Secondary Phase 2 stories may be read during Phase 2 or anytime after.",
+					"color": "#8abdd4"
+				},
+				{
+					"id": "plan",
+					"description": "Unpublished - Future Plans",
+					"details": "Includes all planned future cosmere stories. Likelihood of publication varies. Known publication dates may be in parenthesis. Titles are tentative.",
+					"color": "#505050"
+				},
+				{
+					"id": "apocryphal",
+					"description": "Unpublished - Apocryphal",
+					"details": "Includes unpublished, apocryphal stories. Some elements may be part of the official continuity. Some may be published in the future while others will not.",
+					"color": "#735a45"
+				}
+			]
+		},
+		{
+			"id": "formats",
+			"name": "Formats",
+			"startCollapsed": true,
+			"categories": [
+				{
+					"id": "novel",
+					"description": "Novels",
+					"details": "Full novels.",
+					"color": "#fc4422"
+				},
+				{
+					"id": "graphic",
+					"description": "Graphic Novels",
+					"details": "Graphic novels.",
+					"style": "italic",
+					"color": "#fe8062"
+				},
+				{
+					"id": "novella",
+					"description": "Novellas",
+					"details": "Novellas.",
+					"style": "italic",
+					"color": "#ffc8ba"
+				},
+				{
+					"id": "short",
+					"description": "Short Stories",
+					"details": "Short stories.",
+					"style": "italic",
+					"color": "#fbe8e6"
+				}
+			]
+		}
+	],
+	"sorting": [
+		{
+			"id": "order",
+			"description": "Reading order"
+		},
+		{
+			"id": "publication",
+			"description": "Publication date"
+		},
+		{
+			"id": "chronology",
+			"description": "Cosmere timeline"
+		}
+	],
+	"appearances": [
+		{
+			"id": "hoid",
+			"description": "Hoid",
+			"initial": "H",
+			"color": "#A0A0A0",
+			"details": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a>'s appearances (solid) and mentions (outline)."
+		},
+		{
+			"id": "khriss",
+			"description": "Khriss",
+			"initial": "K",
+			"color": "#A0A0A0",
+			"details": "<a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a>'s appearances (solid) and mentions (outline), not counting the <a target='_blank' href='https://coppermind.net/wiki/Ars_Arcanum'>Ars Arcanum</a>."
+		},
+		{
+			"id": "nazh",
+			"description": "Nazh",
+			"initial": "N",
+			"color": "#A0A0A0",
+			"details": "<a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a>'s appearances (solid) and mentions (outline)."
+		},
+		{
+			"id": "ars",
+			"description": "Ars Arcanum",
+			"initial": "A",
+			"color": "#A0A0A0",
+			"details": "Stories that include an <a target='_blank' href='https://coppermind.net/wiki/Ars_Arcanum'>Ars Arcanum</a>."
+		}
+	],
+	"books": [
+		{
+			"label": "Sel",
+			"color": "#58b06e",
+			"children": [
+				{
+					"label": "Elantris",
+					"children": [
+						{
+							"id": "elantris",
+							"title": "Elantris",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Elantris'>Elantris</a>",
+							"series": "Elantris",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Sel'>Sel</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Selish_system'>Selish system</a>",
+							"publication": "April 2005",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/298/#e9926'>Occurs long before Mistborn Era 1, but not thousands of years before.</a>",
+							"sorting": {
+								"order": 1.3,
+								"publication": 2005.04,
+								"chronology": 3.1
+							},
+							"appearances": [
+								{
+									"id": "hoid",
+									"type": "appearance",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a>'s first appearance. <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is the beggar that works with <a target='_blank' href='https://coppermind.net/wiki/Sarene'>Sarene</a> in <a target='_blank' href='https://coppermind.net/wiki/Summary:Elantris#Chapter_58'>Chapter 58</a>. The tenth anniversary edition includes <a target='_blank' href='https://coppermind.net/wiki/Summary:Elantris#Postscript'>a postscript</a> with <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> in it."
+								},
+								{
+									"id": "nazh",
+									"type": "mention",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a>'s annotations can be found on the map of <a target='_blank' href='https://coppermind.net/wiki/Sycla'>Sycla</a>."
+								},
+								{
+									"id": "ars",
+									"type": "appearance"
+								}
+							],
+							"categories": [
+								"elantris",
+								"phase1",
+								"published",
+								"novel"
+							],
+							"connections": [
+								{
+									"target": "tes",
+									"type": "minor",
+									"description": "The map in <a target='_blank' href='https://coppermind.net/wiki/Elantris'>Elantris</a> refers to '<a target='_blank' href='https://coppermind.net/wiki/Rose_Empire'>Rose Barbarians</a>'. There are mentions of <a target='_blank' href='https://coppermind.net/wiki/Svorden'>Svorden</a>, <a target='_blank' href='https://coppermind.net/wiki/Teod'>Teod</a>, and <a target='_blank' href='https://coppermind.net/wiki/Sycla'>Sycla</a>. When escaping the palace, <a target='_blank' href='https://coppermind.net/wiki/Shai'>Shai</a> runs into a <a target='_blank' href='https://coppermind.net/wiki/Shu-Dereth'>Derethi priest</a> (wearing red armor). When she steals the painting she inscribes an <a target='_blank' href='https://coppermind.net/wiki/Aon'>Aon Reo</a> in its place."
+								},
+								{
+									"target": "msh",
+									"type": "significant",
+									"description": "The <a target='_blank' href='https://coppermind.net/wiki/Ire'>Ire</a> are <a target='_blank' href='https://coppermind.net/wiki/Elantrian'>Elantrians</a>. Their symbol is <a target='_blank' href='https://coppermind.net/wiki/Aon'>Aon Ire</a>."
+								},
+								{
+									"target": "sa1",
+									"type": "egg",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Galladon'>Galladon</a> appears in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Way_of_Kings#Interlude_I-1:_Ishikk'>Interlude I-1</a> as 'Grump'. Note his use of 'sule' (friend) and 'kolo' (understand) as well as the <a target='_blank' href='https://coppermind.net/wiki/Duladel'>Dula</a> word 'kayana' (crazy). Also, <a target='_blank' href='https://coppermind.net/wiki/Aona'>Aona</a> and <a target='_blank' href='https://coppermind.net/wiki/Skai'>Skai</a> are mentioned in the <a target='_blank' href='https://coppermind.net/wiki/https://coppermind.net/wiki/The_Way_of_Kings/Epigraphs#The_Letter'>Chapter 22 epigraph</a>."
+								},
+								{
+									"target": "sa3",
+									"type": "minor",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Riino'>Riino</a>, the lighthouse owner in <a target='_blank' href='https://coppermind.net/wiki/Summary:Oathbringer#Chapter_97:_Riino'>Chapter 97</a>, is the <a target='_blank' href='https://coppermind.net/wiki/Hoed'>Hoed</a> <a target='_blank' href='https://coppermind.net/wiki/Raoden'>Raoden</a> and <a target='_blank' href='https://coppermind.net/wiki/Galladon'>Galladon</a> lowered into the <a target='_blank' href='https://coppermind.net/wiki/Devotion's_Perpendicularity'>mountain lake</a>."
+								},
+								{
+									"target": "au",
+									"type": "minor",
+									"description": "The nature of <a target='_blank' href='https://coppermind.net/wiki/Sel'>Sel</a>'s magic is discussed in the <a target='_blank' href='https://coppermind.net/wiki/Selish_system'>Selish system</a> essay."
+								},
+								{
+									"target": "sa4",
+									"type": "minor",
+									"description": "The communication box used by <a target='_blank' href='https://coppermind.net/wiki/Shallan'>Shallan</a> to communicate with <a target='_blank' href='https://coppermind.net/wiki/Mraize'>Mraize</a> and <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> contains a <a target='_blank' href='https://coppermind.net/wiki/Seon'>Seon</a>."
+								},
+								{
+									"target": "mb7",
+									"type": "major",
+									"description": "(WIP) Codenames is Kaise. Shay-I (Moonlight) uses AonDor in chapter 54. Codenames communicate with Kelsier using Seon Dao"
+								}
+							]
+						},
+						{
+							"id": "thoe",
+							"title": "The Hope of Elantris",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Hope_of_Elantris'>The Hope of Elantris</a>",
+							"series": "Elantris",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Sel'>Sel</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Selish_system'>Selish system</a>",
+							"au": "Included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
+							"link": "<a target='_blank' href='https://brandonsanderson.com/elantris-the-hope-of-elantris'>Full text on Brandon's website.</a>",
+							"padding": 12,
+							"publication": "January 2006",
+							"chronology": "Shortly after the events of Elantris, and concerning events during the end of that book.",
+							"sorting": {
+								"order": 1.31,
+								"publication": 2006.01,
+								"chronology": 3.11
+							},
+							"categories": [
+								"elantris",
+								"phase1b",
+								"published",
+								"short"
+							]
+						},
+						{
+							"id": "elantris2",
+							"title": "Elantris 2",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Elantris_sequel'>Elantris 2</a>",
+							"series": "Elantris",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Sel'>Sel</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Selish_system'>Selish system</a>",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/395/#e13072'>A short time jump is planned between Elantris books, with the original main characters still being alive.</a>",
+							"sorting": {
+								"chronology": 3.2
+							},
+							"categories": [
+								"elantris",
+								"plan",
+								"unpublished",
+								"novel"
+							]
+						},
+						{
+							"id": "elantris3",
+							"title": "Elantris 3",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Elantris_finale'>Elantris 3</a>",
+							"series": "Elantris",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Sel'>Sel</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Selish_system'>Selish system</a>",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/395/#e13072'>A short time jump is planned between Elantris books, with the original main characters still being alive.</a>",
+							"sorting": {
+								"chronology": 3.3
+							},
+							"categories": [
+								"elantris",
+								"plan",
+								"unpublished",
+								"novel"
+							]
+						}
+					]
+				},
+				{
+					"children": [
+						{
+							"id": "tes",
+							"title": "The Emperor's Soul",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Emperor&#39s_Soul'>The Emperor's Soul</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Sel'>Sel</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Selish_system'>Selish system</a>",
+							"au": "Included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
+							"publication": "November 2012",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/109/#e1410'>After Elantris, but within the characters' lifetimes.</a> Note this could place it prior to Elantris 2 and/or 3.",
+							"sorting": {
+								"order": 1.4,
+								"publication": 2012.11,
+								"chronology": 3.5
+							},
+							"appearances": [
+								{
+									"id": "hoid",
+									"type": "mention",
+									"description": "The 'Imperial Fool' is <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a>."
+								}
+							],
+							"categories": [
+								"no-series",
+								"phase1b",
+								"published",
+								"novella"
+							],
+							"connections": [
+								{
+									"target": "imperial-fool",
+									"type": "major",
+									"description": "A deleted prologue that contains some canonical elements."
+								},
+								{
+									"target": "au",
+									"type": "minor",
+									"description": "The nature of <a target='_blank' href='https://coppermind.net/wiki/Sel'>Sel</a>'s magic is discussed in the <a target='_blank' href='https://coppermind.net/wiki/Selish_system'>Selish system</a> essay."
+								},
+								{
+									"target": "sa4",
+									"type": "egg",
+									"description": "The <a target='_blank' href='https://coppermind.net/wiki/Fused'>Fused</a> refer to <a target='_blank' href='https://coppermind.net/wiki/aluminum'>aluminum</a> as Ralkalest."
+								},
+								{
+									"target": "mb7",
+									"type": "major",
+									"description": "(WIP) Moonlight is Shai; she uses Forgery on several occasions and takes on the name Shay-I after using her essence mark"
+								}
+							]
+						},
+						{
+							"id": "tes2",
+							"title": "The Emperor's Soul sequel",
+							"title2": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>Untitled Emperor's Soul sequel</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Sel'>Sel</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Selish_system'>Selish system</a>",
+							"categories": [
+								"no-series",
+								"plan",
+								"unpublished",
+								"novella"
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"label": "Scadrial",
+			"color": "#9973bf",
+			"children": [
+				{
+					"label": "Mistborn<br>Era 1",
+					"children": [
+						{
+							"id": "mb1",
+							"title": "Mistborn: The Final Empire",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn:_The_Final_Empire'>Mistborn: The Final Empire</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 1)",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
+							"publication": "July 2006",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/176/#e8494'>Mistborn Era 1 occurs prior to The Stormlight Archive.",
+							"sorting": {
+								"order": 1.11,
+								"publication": 2006.07,
+								"chronology": 4.1
+							},
+							"appearances": [
+								{
+									"id": "hoid",
+									"type": "appearance",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Kelsier'>Kelsier</a> meets with <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> in <a target='_blank' href='https://coppermind.net/wiki/Summary:Mistborn:_The_Final_Empire#Chapter_19'>Chapter 19</a>."
+								},
+								{
+									"id": "nazh",
+									"type": "mention",
+									"description": "Annotations by <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> can be found on the map of <a target='_blank' href='https://coppermind.net/wiki/Luthadel'>Luthadel</a>."
+								},
+								{
+									"id": "ars",
+									"type": "appearance"
+								}
+							],
+							"categories": [
+								"mistborn",
+								"phase1",
+								"published",
+								"novel"
+							]
+						},
+						{
+							"id": "11m",
+							"title": "The Eleventh Metal",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Eleventh_Metal'>The Eleventh Metal</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 1)",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
+							"au": "Included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
+							"padding": 12,
+							"publication": "December 2011",
+							"chronology": "Concerns Kelsier's training, years before Mistborn: The Final Empire.",
+							"sorting": {
+								"order": 1.14,
+								"publication": 2011.12,
+								"chronology": 4.09
+							},
+							"categories": [
+								"mistborn",
+								"short",
+								"phase1b",
+								"published"
+							]
+						},
+						{
+							"id": "mb2",
+							"title": "The Well of Ascension",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Well_of_Ascension'>The Well of Ascension</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 1)",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
+							"publication": "August 2007",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/176/#e8494'>Mistborn Era 1 occurs prior to The Stormlight Archive.",
+							"sorting": {
+								"order": 1.12,
+								"publication": 2007.08,
+								"chronology": 4.2
+							},
+							"appearances": [
+								{
+									"id": "hoid",
+									"type": "appearance",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is among the <a target='_blank' href='https://coppermind.net/wiki/Terris'>Terris</a> refugees in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Well_of_Ascension#Chapter_56'>Chapter 56</a>, <a target='_blank' href='https://wob.coppermind.net/events/130/#e1552'>according to Brandon</a>."
+								},
+								{
+									"id": "nazh",
+									"type": "mention",
+									"description": "Annotations by <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> can be found on the map of <a target='_blank' href='https://coppermind.net/wiki/Luthadel'>Luthadel</a>."
+								},
+								{
+									"id": "ars",
+									"type": "appearance"
+								}
+							],
+							"categories": [
+								"mistborn",
+								"phase1",
+								"published",
+								"novel"
+							],
+							"connections": [
+								{
+									"target": "wb",
+									"type": "egg",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Lemex%27s_nurse'>Lemex's nurse</a> is a <a target='_blank' href='https://coppermind.net/wiki/Terris'>Terriswoman</a>."
+								}
+							]
+						},
+						{
+							"id": "mb3",
+							"title": "The Hero of Ages",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Hero_of_Ages'>The Hero of Ages</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 1)",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
+							"publication": "October 2008",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/176/#e8494'>Mistborn Era 1 occurs prior to The Stormlight Archive.",
+							"sorting": {
+								"order": 1.13,
+								"publication": 2008.10,
+								"chronology": 4.3
+							},
+							"appearances": [
+								{
+									"id": "hoid",
+									"type": "mention",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is the informant that <a target='_blank' href='https://coppermind.net/wiki/Vin'>Vin</a> was supposed to meet with in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Hero_of_Ages#Chapter_27'>Chapter 27</a>."
+								},
+								{
+									"id": "nazh",
+									"type": "mention",
+									"description": "Annotations by <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> can be found on the map of <a target='_blank' href='https://coppermind.net/wiki/Luthadel'>Luthadel</a>."
+								},
+								{
+									"id": "ars",
+									"type": "appearance"
+								}
+							],
+							"categories": [
+								"mistborn",
+								"phase1",
+								"published",
+								"novel"
+							],
+							"connections": [
+								{
+									"target": "sa1",
+									"type": "egg",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Demoux'>Demoux</a> appears in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Way_of_Kings#Interlude_I-1:_Ishikk'>Interlude I-1</a> as 'Thinker'; <a target='_blank' href='https://coppermind.net/wiki/Ishikk'>Ishikk</a> mishears his name as 'Temoo'. <a target='_blank' href='https://coppermind.net/wiki/Ruin'>Ruin</a>'s <a target='_blank' href='https://coppermind.net/wiki/vessel'>vessel</a>, <a target='_blank' href='https://coppermind.net/wiki/Ati'>Ati</a>, is mentioned in the <a target='_blank' href='https://coppermind.net/wiki/https://coppermind.net/wiki/The_Way_of_Kings/Epigraphs#The_Letter'>Chapter 18 epigraph</a>. <a target='_blank' href='https://coppermind.net/wiki/Felt'>Felt</a> worked for the <a target='_blank' href='https://coppermind.net/wiki/House_Venture'>House Venture</a> on <a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>."
+								},
+								{
+									"target": "sa2",
+									"type": "egg",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Wit</a> appears to use <a target='_blank' href='https://coppermind.net/wiki/Allomancy'>emotional Allomancy</a> in <a target='_blank' href='https://coppermind.net/wiki/Summary:Words_of_Radiance#Chapter_45:_Middlefest'>Chapter 45</a>."
+								},
+								{
+									"target": "sa3",
+									"type": "significant",
+									"description": "The <a target='_blank' href='https://coppermind.net/wiki/Oathbringer/Epigraphs#Letters'>Part 2 epigraphs</a> include <a target='_blank' href='https://coppermind.net/wiki/Letters#Third_Oathbringer_Letter'>a letter</a> from <a target='_blank' href='https://coppermind.net/wiki/Sazed'>Sazed</a> to <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a>. <a target='_blank' href='https://coppermind.net/wiki/Felt'>Felt</a> reveals he is from another world."
+								},
+								{
+									"target": "au",
+									"type": "major",
+									"description": "The <a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a> essay discusses the events that occurred in <a target='_blank' href='https://coppermind.net/wiki/The_Hero_of_Ages'>The Hero of Ages</a>."
+								},
+								{
+									"target": "sa4",
+									"type": "significant",
+									"description": "The <a target='_blank' href='https://coppermind.net/wiki/Rhythm_of_War/Epigraphs'>Part 2 Epigraphs</a> are a letter from <a target='_blank' href='https://coppermind.net/wiki/Harmony'>Harmony</a>. <a target='_blank' href='https://coppermind.net/wiki/Fabrial'>Fabrial</a> metals have similar effects as in the <a target='_blank' href='https://coppermind.net/wiki/Metallic_Arts'>Metalic Arts</a>. <a target='_blank' href='https://coppermind.net/wiki/Gereh'>Gereh</a> and <a target='_blank' href='https://coppermind.net/wiki/Axindweth'>Axindweth</a> are <a target='_blank' href='https://coppermind.net/wiki/Feruchemy'>Feruchemists</a>. <a target='_blank' href='https://coppermind.net/wiki/Raysium'>Raysium</a> is associated with <a target='_blank' href='https://coppermind.net/wiki/Odium'>Odium</a> as <a target='_blank' href='https://coppermind.net/wiki/atium'>atium</a> is associated with <a target='_blank' href='https://coppermind.net/wiki/Ruin'>Ruin</a>."
+								}
+							]
+						}
+					]
+				},
+				{
+					"label": "Mistborn<br>Era 2",
+					"children": [
+						{
+							"id": "mb4",
+							"title": "The Alloy of Law",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Alloy_of_Law'>The Alloy of Law</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 2)",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
+							"publication": "November 2011",
+							"chronology": "Mistborn Era 2 occurs <a target='_blank' href='https://wob.coppermind.net/events/260/#e8747'>after Stormlight Archive book 5</a> and <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>before Stormlight Archive book 6</a>.",
+							"sorting": {
+								"order": 2.21,
+								"publication": 2011.11,
+								"chronology": 8.1
+							},
+							"appearances": [
+								{
+									"id": "hoid",
+									"type": "appearance",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is the beggar speaking with <a target='_blank' href='https://coppermind.net/wiki/Joshin_Yomen'>Lord Joshin</a> and <a target='_blank' href='https://coppermind.net/wiki/Mi%27chelle_Yomen'>Lady Mi'chelle</a> in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Alloy_of_Law#Chapter_4'>Chapter 4</a>."
+								},
+								{
+									"id": "nazh",
+									"type": "mention",
+									"description": "Annotations by <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> can be found on the map of <a target='_blank' href='https://coppermind.net/wiki/Elendel'>Elendel</a>."
+								},
+								{
+									"id": "ars",
+									"type": "appearance"
+								}
+							],
+							"categories": [
+								"mistborn",
+								"phase2",
+								"published",
+								"novel"
+							]
+						},
+						{
+							"id": "jak",
+							"title": "Allomancer Jak",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Allomancer_Jak_and_the_Pits_of_Eltania'>Allomancer Jak and the Pits of Eltania</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 2)",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
+							"au": "Included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
+							"padding": 12,
+							"publication": "August 2014",
+							"chronology": "Mistborn Era 2 occurs <a target='_blank' href='https://wob.coppermind.net/events/260/#e8747'>after Stormlight Archive book 5</a> and <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>before Stormlight Archive book 6</a>.",
+							"sorting": {
+								"order": 2.22,
+								"publication": 2014.08,
+								"chronology": 8.05
+							},
+							"categories": [
+								"mistborn",
+								"short",
+								"phase2b",
+								"published"
+							]
+						},
+						{
+							"id": "mb5",
+							"title": "Shadows of Self",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Shadows_of_Self'>Shadows of Self</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 2)",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
+							"publication": "October 2015",
+							"chronology": "Mistborn Era 2 occurs <a target='_blank' href='https://wob.coppermind.net/events/260/#e8747'>after Stormlight Archive book 5</a> and <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>before Stormlight Archive book 6</a>.",
+							"sorting": {
+								"order": 2.23,
+								"publication": 2015.10,
+								"chronology": 8.2
+							},
+							"appearances": [
+								{
+									"id": "hoid",
+									"type": "appearance",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is <a target='_blank' href='https://coppermind.net/wiki/Waxillium_Laddrian'>Wax</a>'s coachman, named in <a target='_blank' href='https://coppermind.net/wiki/Summary:Shadows_of_Self#Chapter_7'>Chapter 7</a>."
+								},
+								{
+									"id": "ars",
+									"type": "appearance"
+								}
+							],
+							"categories": [
+								"mistborn",
+								"phase2",
+								"published",
+								"novel"
+							]
+						},
+						{
+							"id": "mb6",
+							"title": "The Bands of Mourning",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Bands_of_Mourning'>The Bands of Mourning</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 2)",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
+							"publication": "January 2016",
+							"chronology": "Mistborn Era 2 occurs <a target='_blank' href='https://wob.coppermind.net/events/260/#e8747'>after Stormlight Archive book 5</a> and <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>before Stormlight Archive book 6</a>.",
+							"sorting": {
+								"order": 2.24,
+								"publication": 2016.01,
+								"chronology": 8.3
+							},
+							"appearances": [
+								{
+									"id": "hoid",
+									"type": "appearance",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is the beggar who gives <a target='_blank' href='https://coppermind.net/wiki/Waxillium_Laddrian'>Wax</a> a special coin in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Bands_of_Mourning#Chapter_11'>Chapter 11</a>."
+								},
+								{
+									"id": "khriss",
+									"type": "appearance",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> is the woman who dances with <a target='_blank' href='https://coppermind.net/wiki/Waxillium_Laddrian'>Wax</a> in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Bands_of_Mourning#Chapter_12'>Chapter 12</a>. <a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> and <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> are also the 'K or N' referred to in the 'Do your metal tools speak to you?' ad in <a target='_blank' href='https://coppermind.net/wiki/The_New_Ascendancy'>The New Ascendancy</a> broadsheet."
+								},
+								{
+									"id": "nazh",
+									"type": "mention",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> is 'the haunted man' in 'The Ghastly Gondola!' story in <a target='_blank' href='https://coppermind.net/wiki/The_New_Ascendancy'>The New Ascendancy</a> broadsheet. (note his 'shadows' curse) <a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> and <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> are also the 'K or N' referred to in the 'Do your metal tools speak to you?' ad in the broadsheet."
+								},
+								{
+									"id": "ars",
+									"type": "appearance"
+								}
+							],
+							"categories": [
+								"mistborn",
+								"phase2",
+								"published",
+								"novel"
+							],
+							"connections": [
+								{
+									"target": "sa2",
+									"type": "egg",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Iyatil'>Iyatil</a> is of <a target='_blank' href='https://coppermind.net/wiki/Southern_Scadrial'>Southern Scadrian</a> descent."
+								},
+								{
+									"target": "msh",
+									"type": "major",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Kelsier'>Kelsier</a>'s survival is revealed in <a target='_blank' href='https://coppermind.net/wiki/The_Bands_of_Mourning'>The Bands of Mourning</a>."
+								},
+								{
+									"target": "sotd2",
+									"type": "minor",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrian</a> spaceships powered by <a target='_blank' href='https://coppermind.net/wiki/Allomancy'>Allomancy</a> are seen."
+								}
+							]
+						},
+						{
+							"id": "mb7",
+							"title": "The Lost Metal (2022)",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Lost_Metal'>The Lost Metal</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 2)",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
+							"publication": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>Fall 2022</a>",
+							"chronology": "Mistborn Era 2 occurs <a target='_blank' href='https://wob.coppermind.net/events/260/#e8747'>after Stormlight Archive book 5</a> and <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>before Stormlight Archive book 6</a>.",
+							"sorting": {
+								"publication": 2022.11,
+								"chronology": 8.4
+							},
+							"appearances": [
+								{
+									"id": "hoid",
+									"type": "appearance",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is <a target='_blank' href='https://coppermind.net/wiki/Waxillium_Laddrian'>Wax</a>'s coachman, named for the first time in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Lost_Metal#Chapter_7'>Chapter 7</a>."
+								},
+								{
+									"id": "nazh",
+									"type": "mention",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> is 'the haunted man' in 'Nicki Savage and The Compass of Spirits' story in <a target='_blank' href='https://coppermind.net/wiki/The_Two_Seasons'>The Two Seasons</a> broadsheet."
+								},
+								{
+									"id": "ars",
+									"type": "appearance"
+								}
+							],
+							"categories": [
+								"mistborn",
+								"plan",
+								"forthcoming",
+								"novel"
+							]
+						},
+						{
+							"id": "nicki",
+							"title": "Boatload of Mummies",
+							"title2": "<a target='_blank' href='https://wob.coppermind.net/events/479/#e15159'>Boatload of Mummies</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 2)",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
+							"chronology": "Mistborn Era 2 occurs <a target='_blank' href='https://wob.coppermind.net/events/260/#e8747'>after Stormlight Archive book 5</a> and <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>before Stormlight Archive book 6</a>.",
+							"padding": 12,
+							"sorting": {
+								"chronology": 8.5
+							},
+							"categories": [
+								"mistborn",
+								"short",
+								"plan",
+								"unpublished"
+							]
+						}
+					]
+				},
+				{
+					"label": "Mistborn<br>Era 3",
+					"children": [
+						{
+							"id": "mb8",
+							"title": "Mistborn Era 3 Book 1",
+							"title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=mistborn+era+3'>Mistborn Era 3 Book 1</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 3)",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>Fifty to seventy years after Mistborn Era 2. After Stormlight Archive book 10.</a> Prior to Mistborn Era 4.",
+							"publication": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>2024 (best guess)</a>",
+							"sorting": {
+								"chronology": 10.1,
+								"publication": 2024
+							},
+							"categories": [
+								"mistborn",
+								"plan",
+								"unpublished",
+								"novel"
+							]
+						},
+						{
+							"id": "mb9",
+							"title": "Mistborn Era 3 Book 2",
+							"title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=mistborn+era+3'>Mistborn Era 3 Book 2</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 3)",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>Fifty to seventy years after Mistborn Era 2. After Stormlight Archive book 10.</a> Prior to Mistborn Era 4.",
+							"publication": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>2025 (best guess)</a>",
+							"sorting": {
+								"chronology": 10.2,
+								"publication": 2025
+							},
+							"categories": [
+								"mistborn",
+								"plan",
+								"unpublished",
+								"novel"
+							]
+						},
+						{
+							"id": "mb10",
+							"title": "Mistborn Era 3 Book 3",
+							"title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=mistborn+era+3'>Mistborn Era 3 Book 3</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 3)",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>Fifty to seventy years after Mistborn Era 2. After Stormlight Archive book 10.</a> Prior to Mistborn Era 4.",
+							"publication": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>2026 (best guess)</a>",
+							"sorting": {
+								"chronology": 10.3,
+								"publication": 2026
+							},
+							"categories": [
+								"mistborn",
+								"plan",
+								"unpublished",
+								"novel"
+							]
+						}
+					]
+				},
+				{
+					"label": "Mistborn<br>Era 4",
+					"children": [
+						{
+							"id": "mb11",
+							"title": "Mistborn Era 4 Book 1",
+							"title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=mistborn+era+4'>Mistborn Era 4 Book 1</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 4)",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/182/#e3884'>Mistborn Era 4 is the finale of the cosmere storyline.</a>",
+							"sorting": {
+								"chronology": 13.1
+							},
+							"categories": [
+								"mistborn",
+								"plan",
+								"unpublished",
+								"novel"
+							]
+						},
+						{
+							"id": "mb12",
+							"title": "Mistborn Era 4 Book 2",
+							"title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=mistborn+era+4'>Mistborn Era 4 Book 2</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 4)",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/182/#e3884'>Mistborn Era 4 is the finale of the cosmere storyline.</a>",
+							"sorting": {
+								"chronology": 13.2
+							},
+							"categories": [
+								"mistborn",
+								"plan",
+								"unpublished",
+								"novel"
+							]
+						},
+						{
+							"id": "mb13",
+							"title": "Mistborn Era 4 Book 3",
+							"title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=mistborn+era+4'>Mistborn Era 4 Book 3</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 4)",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/182/#e3884'>Mistborn Era 4 is the finale of the cosmere storyline.</a>",
+							"sorting": {
+								"chronology": 13.3
+							},
+							"categories": [
+								"mistborn",
+								"plan",
+								"unpublished",
+								"novel"
+							]
+						}
+					]
+				},
+				{
+					"label": "Other<br>Mistborn",
+					"children": [
+						{
+							"id": "msh",
+							"title": "Mistborn: Secret History",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn:_Secret_History'>Mistborn: Secret History</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
+							"au": "Included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
+							"publication": "January 2016",
+							"chronology": "Happens concurrently with Mistborn Era 1.",
+							"sorting": {
+								"order": 2.25,
+								"publication": 2016.01,
+								"chronology": 4.11
+							},
+							"appearances": [
+								{
+									"id": "hoid",
+									"type": "appearance",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is 'Drifter'."
+								},
+								{
+									"id": "khriss",
+									"type": "appearance",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Kelsier'>Kelsier</a> meets <a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> and <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> in the <a target='_blank' href='https://coppermind.net/wiki/Cognitive_Realm'>Cognitive Realm</a>."
+								},
+								{
+									"id": "nazh",
+									"type": "appearance",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Kelsier'>Kelsier</a> meets <a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> and <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> in the <a target='_blank' href='https://coppermind.net/wiki/Cognitive_Realm'>Cognitive Realm</a>."
+								}
+							],
+							"categories": [
+								"mistborn",
+								"novella",
+								"phase2",
+								"published"
+							],
+							"connections": [
+								{
+									"target": "sa1",
+									"type": "egg",
+									"description": "In <a target='_blank' href='https://coppermind.net/wiki/Summary:Mistborn:_Secret_History#Chapter_2_5'>Part 5 Chapter 2</a> <a target='_blank' href='https://coppermind.net/wiki/Kelsier'>Kelsier</a> sees an <a target='_blank' href='https://coppermind.net/wiki/Fabrial'>alerter fabrial</a> (the glowing yellow gemstone in a golden metal lattice)."
+								},
+								{
+									"target": "sa2",
+									"type": "egg",
+									"description": "With powers gained from the <a target='_blank' href='https://coppermind.net/wiki/lerasium'>lerasium</a> he took, <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> uses <a target='_blank' href='https://coppermind.net/wiki/Allomancy'>emotional Allomancy</a> in <a target='_blank' href='https://coppermind.net/wiki/Summary:Words_of_Radiance#Chapter_45:_Middlefest'>Chapter 45</a>."
+								},
+								{
+									"target": "traveler",
+									"type": "major",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> and <a target='_blank' href='https://coppermind.net/wiki/Frost'>Frost</a> discuss the events of <a target='_blank' href='https://coppermind.net/wiki/The_Hero_of_Ages'>The Hero of Ages</a> (and <a target='_blank' href='https://coppermind.net/wiki/Mistborn:_Secret_History'>Mistborn: Secret History</a>)."
+								},
+								{
+									"target": "sa4",
+									"type": "significant",
+									"description": "Thaidakar, leader of the <a target='_blank' href='https://coppermind.net/wiki/Ghostbloods'>Ghostbloods</a> is <a target='_blank' href='https://coppermind.net/wiki/Kelsier'>Kelsier</a>, with the fight between him and <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> in <a target='_blank' href='https://coppermind.net/wiki/Mistborn:_Secret_History'>Secret History</a> specifically referenced. <a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a> is referenced in <a target='_blank' href='https://coppermind.net/wiki/Ialai'>Ialai's</a> notes. The device used by the <a target='_blank' href='https://coppermind.net/wiki/honorspren'>honorspren</a> to store <a target='_blank' href='https://coppermind.net/wiki/Stormlight'>Stormlight</a> came from the <a target='_blank' href='https://coppermind.net/wiki/Ire'>Ire</a>."
+								},
+								{
+									"target": "mb7",
+									"type": "significant",
+									"description": "(WIP) Kelsier's survival is made explicit in Secret History. The glowing jars that the Ire are using are likely purified Dor."
+								}
+							]
+						},
+						{
+							"id": "msh2",
+							"title": "Mistborn: Secret History 2",
+							"title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=mistborn%3A+secret+history+2'>Mistborn: Secret History 2</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
+							"categories": [
+								"mistborn",
+								"novella",
+								"plan",
+								"unpublished"
+							]
+						},
+						{
+							"id": "mb-cyberpunk",
+							"title": "Cyberpunk Mistborn",
+							"title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?query=cyberpunk%2Bmistborn&date_from=2003-12-05&date_to=2019-11-20&speaker=&ordering=rank'>Cyberpunk Mistborn</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
+							"chronology": "A cyberpunk Mistborn series would be in a <a target='_blank' href='https://wob.coppermind.net/events/34/#e1782'>near-future setting</a>, between Eras 3 and 4.",
+							"sorting": {
+								"chronology": 10.7
+							},
+							"categories": [
+								"mistborn",
+								"plan",
+								"unpublished",
+								"novel"
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"label": "Nalthis",
+			"color": "#de4343",
+			"children": [
+				{
+					"label": "Warbreaker",
+					"color": "#de4343",
+					"children": [
+						{
+							"id": "wb",
+							"title": "Warbreaker",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Warbreaker'>Warbreaker</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Nalthis'>Nalthis</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Nalthian_system'>Nalthian system</a>",
+							"publication": "June 2009",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/309/#e10273'>Occurs after Mistborn Era 1 and before The Stormlight Archive.</a>",
+							"link": "Full text: <a target='_blank' href='https://www.brandonsanderson.com/warbreaker-rights-and-downloads/'>Brandon's website</a> | <a target='_blank' href='https://github.com/guusj/books'>Alternate file types</a>",
+							"sorting": {
+								"order": 1.2,
+								"publication": 2009.06,
+								"chronology": 5.1
+							},
+							"appearances": [
+								{
+									"id": "hoid",
+									"type": "appearance",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is the master storyteller in <a target='_blank' href='https://coppermind.net/wiki/Summary:Warbreaker#Chapter_32'>Chapter 32</a>."
+								},
+								{
+									"id": "ars",
+									"type": "appearance"
+								}
+							],
+							"categories": [
+								"warbreaker",
+								"phase1",
+								"published",
+								"novel"
+							],
+							"connections": [
+								{
+									"target": "sa2",
+									"type": "significant",
+									"description": "Zahel is <a target='_blank' href='https://coppermind.net/wiki/Vasher'>Vasher</a>. <a target='_blank' href='https://coppermind.net/wiki/Szeth'>Szeth</a>'s new <a target='_blank' href='https://coppermind.net/wiki/Shardblade'>Shardblade</a> is <a target='_blank' href='https://coppermind.net/wiki/Nightblood'>Nightblood</a>. <a target='_blank' href='https://coppermind.net/wiki/Mraize'>Mraize</a>'s collection in <a target='_blank' href='https://coppermind.net/wiki/Summary:Words_of_Radiance#Chapter_43:_The_Ghostbloods'>Chapter 43</a> includes a <a target='_blank' href='https://coppermind.net/wiki/Tears_of_Edgli'>Tear of Edgli</a> flower."
+								},
+								{
+									"target": "sa3",
+									"type": "major",
+									"description": "Azure is <a target='_blank' href='https://coppermind.net/wiki/Vivenna'>Vivenna</a>; she uses <a target='_blank' href='https://coppermind.net/wiki/Awakening'>Awakening</a> on several occaisions and has an Awakened sword. <a target='_blank' href='https://coppermind.net/wiki/Nightblood'>Nightblood</a> and <a target='_blank' href='https://coppermind.net/wiki/Vasher'>Vasher</a> make significant appearances. <a target='_blank' href='https://coppermind.net/wiki/Nightblood'>Nightblood</a> mentions <a target='_blank' href='https://coppermind.net/wiki/Denth'>Denth</a>, <a target='_blank' href='https://coppermind.net/wiki/Shashara'>Shashara</a>, and <a target='_blank' href='https://coppermind.net/wiki/Vivenna'>Vivenna</a> by name. A painting from the <a target='_blank' href='https://coppermind.net/wiki/Court_of_Gods'>Court of Gods</a> appears in <a target='_blank' href='https://coppermind.net/wiki/Summary:Oathbringer#Chapter_102:_Celebrant'>Chapter 102</a>. <a target='_blank' href='https://coppermind.net/wiki/Riino'>Riino</a> mentions <a target='_blank' href='https://coppermind.net/wiki/Heightening'>Heightenings</a>. <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> uses <a target='_blank' href='https://coppermind.net/wiki/Awakening'>Awakening</a> in the <a target='_blank' href='https://coppermind.net/wiki/Summary:Oathbringer#Epilogue:_Great_Art'>Epilogue</a>."
+								},
+								{
+									"target": "sa3.5",
+									"type": "minor",
+									"description": "The <a target='_blank' href='https://coppermind.net/wiki/Dawnshard'>Dawnshard</a> causes <a target='_blank' href='https://coppermind.net/wiki/Rysn_Ftori'>Rysn</a> to experience several effects similar to the <a target='_blank' href='https://coppermind.net/wiki/BioChromatic_Breath'>Heightenings associated with Breath</a>."
+								},
+								{
+									"target": "sa4",
+									"type": "major",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Nightblood'>Nightblood</a> is used to kill <a target='_blank' href='https://coppermind.net/wiki/Rayse'>Rayse</a>. <a target='_blank' href='https://coppermind.net/wiki/Ialai'>Ialai's</a> notes mention <a target='_blank' href='https://coppermind.net/wiki/Nalthis'>Nalthis</a>. <a target='_blank' href='https://coppermind.net/wiki/Zahel'>Zahel</a> uses <a target='_blank' href='https://coppermind.net/wiki/Awakening'>Awakening</a> in his fight against <a target='_blank' href='https://coppermind.net/wiki/Kaladin'>Kaladin</a> and explains that he is a <a target='_blank' href='https://coppermind.net/wiki/Cognitive_Shadow'>Cognitive Shadow</a>. The coin <a target='_blank' href='https://coppermind.net/wiki/Adolin'>Adolin</a> gives to <a target='_blank' href='https://coppermind.net/wiki/Kaladin'>Kaladin</a> and some merchants in <a target='_blank' href='https://coppermind.net/wiki/Lasting_Integrity'>Lasting Integrity</a> are from <a target='_blank' href='https://coppermind.net/wiki/Nalthis'>Nalthis</a>. <a target='_blank' href='https://coppermind.net/wiki/Endowment'>Endowment</a> is referenced in the <a target='_blank' href='https://coppermind.net/wiki/Rhythm_of_War/Epigraphs'>Chapter 24 epigraph</a>. <a target='_blank' href='https://coppermind.net/wiki/Odium'>Odium</a> tampers with <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid's</a> <a target='_blank' href='https://coppermind.net/wiki/BioChromatic_Breath'>Breath</a> in the Epilogue."
+								},
+								{
+									"target": "mb7",
+									"type": "significant",
+									"description": "(WIP) Nalthis is mentionned in chapter 39. Moonlight describes an Awakened lock in chapter 40."
+								}
+							]
+						},
+						{
+							"id": "nb",
+							"title": "Nightblood",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Nightblood_(book)'>Nightblood</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Nalthis'>Nalthis</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Nalthian_system'>Nalthian system</a>",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/87/#e5657'>This sequel occurs prior to The Stormlight Archive.</a>",
+							"sorting": {
+								"chronology": 5.2
+							},
+							"categories": [
+								"warbreaker",
+								"plan",
+								"unpublished",
+								"novel"
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"label": "Roshar",
+			"color": "#2aa1d4",
+			"children": [
+				{
+					"label": "The Stormlight Archive",
+					"children": [
+						{
+							"id": "sa1",
+							"title": "The Way of Kings",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Way_of_Kings'>The Way of Kings</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+							"publication": "August 2010",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/309/#e10273'>Occurs after Mistborn Era 1 and Warbreaker but before Mistborn Era 2.</a>",
+							"sorting": {
+								"order": 2.41,
+								"publication": 2010.08,
+								"chronology": 7.01
+							},
+							"appearances": [
+								{
+									"id": "hoid",
+									"type": "appearance",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is 'Wit'."
+								},
+								{
+									"id": "ars",
+									"type": "appearance"
+								}
+							],
+							"categories": [
+								"stormlight",
+								"phase2",
+								"published",
+								"novel"
+							],
+							"connections": [
+								{
+									"target": "mb7",
+									"type": "minor",
+									"description": "(WIP) Moonlight mentions Odium in chapter 20. Wayne buys some chouta from a street vendor in chapter 32. Codenames mentions Roshar and the Thaylen language in chapter 39."
+								}
+							]
+						},
+						{
+							"id": "sa2",
+							"title": "Words of Radiance",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Words_of_Radiance'>Words of Radiance</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+							"publication": "March 2014",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/309/#e10273'>Occurs after Mistborn Era 1 and Warbreaker but before Mistborn Era 2.</a>",
+							"sorting": {
+								"order": 2.42,
+								"publication": 2014.03,
+								"chronology": 7.02
+							},
+							"appearances": [
+								{
+									"id": "hoid",
+									"type": "appearance",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is 'Wit'."
+								},
+								{
+									"id": "nazh",
+									"type": "appearance",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a> is the <a target='_blank' href='https://coppermind.net/wiki/Ardent'>ardent</a> trying to get a sketch of <a target='_blank' href='https://coppermind.net/wiki/Bridge_Four'>Bridge Four</a>'s tattoo in <a target='_blank' href='https://coppermind.net/wiki/Summary:Words_of_Radiance#Chapter_31:_The_Stillness_Before'>Chapter 31</a>. Several drawings and sketches also include his annotations."
+								},
+								{
+									"id": "ars",
+									"type": "appearance"
+								}
+							],
+							"categories": [
+								"stormlight",
+								"phase2",
+								"published",
+								"novel"
+							],
+							"connections": [
+								{
+									"target": "jasnah",
+									"type": "major",
+									"description": "A deleted scene about <a target='_blank' href='https://coppermind.net/wiki/Jasnah_Kholin'>Jasnah</a> that contains some canonical elements."
+								},
+								{
+									"target": "traveler",
+									"type": "minor",
+									"description": "The man <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> speaks with is <a target='_blank' href='https://coppermind.net/wiki/Frost'>Frost</a>, who responded to <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> with similar opinions in the <a target='_blank' href='https://coppermind.net/wiki/Words_of_Radiance/Epigraphs#The_Second_Letter'>Words of Radiance Part 4 epigraphs</a>."
+								},
+								{
+									"target": "au",
+									"type": "minor",
+									"description": "The <a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a> essay covers details about <a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a> and makes mentions of <a target='_blank' href='https://coppermind.net/wiki/Odium'>Odium</a>'s past."
+								},
+								{
+									"target": "mb7",
+									"type": "egg",
+									"description": "(WIP) Dlavil is Iyatil's Brother"
+								}
+							]
+						},
+						{
+							"id": "sa2.5",
+							"title": "Edgedancer",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Edgedancer'>Edgedancer</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+							"au": "Included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
+							"padding": 12,
+							"publication": "November 2016",
+							"chronology": "Occurs after Words of Radiance and concurrently with the early events of Oathbringer.",
+							"sorting": {
+								"order": 2.43,
+								"publication": 2016.11,
+								"chronology": 7.025
+							},
+							"appearances": [
+								{
+									"id": "hoid",
+									"type": "mention",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is 'Ol' Whitehair', mentioned in <a target='_blank' href='https://coppermind.net/wiki/Summary:Edgedancer#Chapter_12'>Chapter 12</a>."
+								}
+							],
+							"categories": [
+								"stormlight",
+								"novella",
+								"phase2",
+								"published"
+							]
+						},
+						{
+							"id": "sa3",
+							"title": "Oathbringer",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Oathbringer'>Oathbringer</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+							"publication": "November 2017",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/309/#e10273'>Occurs after Mistborn Era 1 and Warbreaker but before Mistborn Era 2.</a>",
+							"sorting": {
+								"order": 2.44,
+								"publication": 2017.11,
+								"chronology": 7.03
+							},
+							"appearances": [
+								{
+									"id": "hoid",
+									"type": "appearance",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is 'Wit'."
+								},
+								{
+									"id": "nazh",
+									"type": "mention",
+									"description": "Several drawings and sketches include <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a>'s annotations. Most notably, the <a target='_blank' href='https://coppermind.net/wiki/Glyphs'>glyphs</a> page is entirely written by him."
+								},
+								{
+									"id": "ars",
+									"type": "appearance"
+								}
+							],
+							"categories": [
+								"stormlight",
+								"phase2",
+								"published",
+								"novel"
+							],
+							"connections": [
+								{
+									"target": "twokp",
+									"type": "minor",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/The_Way_of_Kings_Prime'>The Way of Kings Prime</a>, written in 2002, is the original draft of <a target='_blank' href='https://coppermind.net/wiki/The_Way_of_Kings'>The Way of Kings</a>. Only small excerpts were released prior to <a target='_blank' href='https://coppermind.net/wiki/The_Way_of_Kings'>Oathbringer</a> as Brandon felt it contained spoilers for certain ideas through that book. It was self-published as a Sanderson Curiosity in July 2020."
+								}
+							]
+						},
+						{
+							"id": "sa3.5",
+							"title": "Dawnshard",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Dawnshard_(novella)'>Dawnshard</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+							"publication": "November 2020",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/406/#e13986'>Between Oathbringer and Rhythm of War.</a>",
+							"padding": 12,
+							"sorting": {
+								"order": 2.45,
+								"publication": 2020.1105,
+								"chronology": 7.035
+							},
+							"categories": [
+								"stormlight",
+								"novella",
+								"published",
+								"phase2"
+							]
+						},
+						{
+							"id": "sa4",
+							"title": "Rhythm of War",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Rhythm_of_War'>Rhythm of War</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+							"publication": "November 2020",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/309/#e10273'>Occurs after Mistborn Era 1 and Warbreaker but before Mistborn Era 2.</a>",
+							"sorting": {
+								"order": 2.46,
+								"publication": 2020.1117,
+								"chronology": 7.04
+							},
+							"appearances": [
+								{
+									"id": "hoid",
+									"type": "appearance",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is 'Wit'."
+								},
+								{
+									"id": "nazh",
+									"type": "mention",
+									"description": "Several drawings and sketches include <a target='_blank' href='https://coppermind.net/wiki/Nazrilof'>Nazh</a>'s annotations. Most notably, the <a target='_blank' href='https://coppermind.net/wiki/Glyphs'>glyphs</a> page is entirely written by him."
+								},
+								{
+									"id": "ars",
+									"type": "appearance"
+								}
+							],
+							"categories": [
+								"stormlight",
+								"novel",
+								"phase2",
+								"published"
+							],
+							"connections": [
+								{
+									"target": "d1",
+									"type": "egg",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Microkinesis'>Microkinesis</a> referes to a type of magic from <a target='_blank' href='https://coppermind.net/wiki/Yolen'>Yolen</a> in <a target='_blank' href='https://coppermind.net/wiki/Dragonsteel'>Dragonsteel</a>."
+								},
+								{
+									"target": "mb2",
+									"type": "minor",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Ati'>Ati</a> speaks to <a target='_blank' href='https://coppermind.net/wiki/Vin'>Vin</a> and others with <a target='_blank' href='https://coppermind.net/wiki/Ruin'>Ruin's</a> <a target='_blank' href='https://coppermind.net/wiki/Rhythm#The_Pure_Tones'>Pure Tone</a>. The <a target='_blank' href='https://coppermind.net/wiki/Well_of_Ascension'>Well of Ascension</a> pulses with <a target='_blank' href='https://coppermind.net/wiki/Preservation'>Preservation's</a> <a target='_blank' href='https://coppermind.net/wiki/Rhythm#The_Pure_Tones'>Pure Tone</a>"
+								}
+							]
+						},
+						{
+							"id": "sa4.5",
+							"title": "Horneater (2023)",
+							"title2": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2019/'>Horneater</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+							"padding": 12,
+							"chronology": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>Fills in what happened with Rock after the events of Rhythm of War.</a>",
+							"sorting": {
+								"publication": 2023.11,
+								"chronology": 7.045
+							},
+							"categories": [
+								"stormlight",
+								"novella",
+								"plan",
+								"unpublished"
+							]
+						},
+						{
+							"id": "sa5",
+							"title": "Stormlight Archive 5 (2024)",
+							"title2": "Stormlight Archive 5",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+							"publication": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>Fall 2023</a>",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/309/#e10273'>Occurs after Mistborn Era 1 and Warbreaker but before Mistborn Era 2.</a>",
+							"sorting": {
+								"publication": 2023.11,
+								"chronology": 7.05
+							},
+							"categories": [
+								"stormlight",
+								"plan",
+								"forthcoming",
+								"novel"
+							]
+						},
+						{
+							"id": "lopen",
+							"title": "King Lopen the First",
+							"title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=king+lopen+the+first+of+alethkar'>King Lopen the First of Alethkar</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/31/#e1703'>Occurs concurrently with the final events of Words of Radiance.</a>",
+							"padding": 12,
+							"sorting": {
+								"chronology": 7.022
+							},
+							"categories": [
+								"stormlight",
+								"short",
+								"plan",
+								"unpublished"
+							]
+						},
+						{
+							"id": "tdatd",
+							"title": "The Dog and the Dragon",
+							"title2": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>The Dog and the Dragon picture book</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+							"padding": 12,
+							"categories": [
+								"stormlight",
+								"plan",
+								"unpublished",
+								"graphic"
+							]
+						},
+						{
+							"id": "tgwlu",
+							"title": "The Girl Who Looked Up",
+							"title2": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>The Girl Who Looked Up picture book</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+							"padding": 12,
+							"categories": [
+								"stormlight",
+								"plan",
+								"unpublished",
+								"graphic"
+							]
+						},
+						{
+							"id": "sa-art",
+							"title": "Stormlight Archive art book",
+							"title2": "<a target='_blank' href='https://wob.coppermind.net/events/396/#e13175'>Stormlight Archive art book</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+							"padding": 12,
+							"categories": [
+								"stormlight",
+								"plan",
+								"unpublished",
+								"graphic"
+							]
+						},
+						{
+							"id": "sa6",
+							"title": "Stormlight Archive 6",
+							"title2": "Stormlight Archive 6",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/61/#e1300'>There's a roughly 15 year gap between Stormlight 5 and 6.</a> <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>Occurs after Mistborn Era 2 and before Mistborn Era 3.</a>",
+							"publication": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>2028 (best guess)</a>",
+							"sorting": {
+								"chronology": 9.06,
+								"publication": 2028
+							},
+							"categories": [
+								"stormlight",
+								"plan",
+								"unpublished",
+								"novel"
+							]
+						},
+						{
+							"id": "sa7",
+							"title": "Stormlight Archive 7",
+							"title2": "Stormlight Archive 7",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/61/#e1300'>There's a roughly 15 year gap between Stormlight 5 and 6.</a> <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>Occurs after Mistborn Era 2 and before Mistborn Era 3.</a>",
+							"sorting": {
+								"chronology": 9.07
+							},
+							"categories": [
+								"stormlight",
+								"plan",
+								"unpublished",
+								"novel"
+							]
+						},
+						{
+							"id": "sa8",
+							"title": "Stormlight Archive 8",
+							"title2": "Stormlight Archive 8",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/61/#e1300'>There's a roughly 15 year gap between Stormlight 5 and 6.</a> <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>Occurs after Mistborn Era 2 and before Mistborn Era 3.</a>",
+							"sorting": {
+								"chronology": 9.08
+							},
+							"categories": [
+								"stormlight",
+								"plan",
+								"unpublished",
+								"novel"
+							]
+						},
+						{
+							"id": "sa9",
+							"title": "Stormlight Archive 9",
+							"title2": "Stormlight Archive 9",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/61/#e1300'>There's a roughly 15 year gap between Stormlight 5 and 6.</a> <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>Occurs after Mistborn Era 2 and before Mistborn Era 3.</a>",
+							"sorting": {
+								"chronology": 9.09
+							},
+							"categories": [
+								"stormlight",
+								"plan",
+								"unpublished",
+								"novel"
+							]
+						},
+						{
+							"id": "sa10",
+							"title": "Stormlight Archive 10",
+							"title2": "Stormlight Archive 10",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/61/#e1300'>There's a roughly 15 year gap between Stormlight 5 and 6.</a> <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>Occurs after Mistborn Era 2 and before Mistborn Era 3.</a>",
+							"sorting": {
+								"chronology": 9.10
+							},
+							"categories": [
+								"stormlight",
+								"plan",
+								"unpublished",
+								"novel"
+							],
+							"connections": [
+								{
+									"target": "sotd2",
+									"type": "minor",
+									"description": "A <a target='_blank' href='https://coppermind.net/wiki/Knights_Radiant'>Knight Radiant</a> makes an appearance, weilding a 'Shardgun'."
+								}
+							]
+						}
+					]
+				},
+				{
+					"children": [
+						{
+							"id": "tsd",
+							"title": "The Silence Divine",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Silence_Divine'>The Silence Divine</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Ashyn'>Ashyn</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+							"link": "<a target='_blank' href='https://wob.coppermind.net/events/201/#e12303'>Excerpt on Arcanum.</a>",
+							"publication": "March 2014",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/370/#e11901'>Occurs late in the Stormlight Archive era, around book 8.</a>",
+							"sorting": {
+								"publication": 2014.03,
+								"chronology": 9.081
+							},
+							"categories": [
+								"no-series",
+								"plan",
+								"unpublished",
+								"novella"
+							],
+							"connections": [
+								{
+									"target": "sa3",
+									"type": "minor",
+									"description": "The Silence Divine is set on <a target='_blank' href='https://coppermind.net/wiki/Ashyn'>Ashyn</a>, the world that the humans fled to <a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a> from."
+								}
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"label": "Taldain",
+			"color": "#d4c955",
+			"children": [
+				{
+					"label": "White Sand",
+					"children": [
+						{
+							"id": "ws1",
+							"title": "White Sand Volume 1",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/White_Sand_Volume_1'>White Sand Volume 1</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/White_Sand'>White Sand</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Taldain_system'>Taldain system</a>",
+							"au": "Excerpt included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
+							"publication": "June 2016",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/182/#e3878'>White Sand occurs prior to Elantris.</a>",
+							"sorting": {
+								"order": 2.11,
+								"publication": 2016.06,
+								"chronology": 2.1
+							},
+							"appearances": [
+								{
+									"id": "hoid",
+									"type": "appearance",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is the hooded man with a stringed instrument who first appears in <a target='_blank' href='https://coppermind.net/wiki/Ais'>Ais</a>'s first scene in the middle of <a target='_blank' href='https://coppermind.net/wiki/Summary:White_Sand_Volume_1#Chapter_4:_Divides'>Chapter 4</a>."
+								},
+								{
+									"id": "khriss",
+									"type": "appearance",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> is a main character."
+								}
+							],
+							"categories": [
+								"white-sand",
+								"phase2b",
+								"published",
+								"graphic"
+							],
+							"connections": [
+								{
+									"target": "mb1",
+									"type": "egg",
+									"description": "'Kenton Street' in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Well_of_Ascension#Chapter_17'>Chapter 17</a> (also mentioned in <a target='_blank' href='https://coppermind.net/wiki/The_Well_of_Ascension'>The Well of Ascension) is a reference to <a target='_blank' href='https://coppermind.net/wiki/Kenton'>Kenton</a>."
+								},
+								{
+									"target": "sa2",
+									"type": "egg",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Mraize'>Mraize</a>'s collection in <a target='_blank' href='https://coppermind.net/wiki/Summary:Words_of_Radiance#Chapter_43:_The_Ghostbloods'>Chapter 43</a> includes a vial of sand from <a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a>."
+								},
+								{
+									"target": "au",
+									"type": "minor",
+									"description": "The <a target='_blank' href='https://coppermind.net/wiki/Taldain_system'>Taldain system</a> essay discusses <a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a> and <a target='_blank' href='https://coppermind.net/wiki/Sand_mastery'>sand mastery</a>."
+								},
+								{
+									"target": "sa4",
+									"type": "minor",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a> is referenced in <a target='_blank' href='https://coppermind.net/wiki/Ialai'>Ialai's</a> notes."
+								},
+								{
+									"target": "mb7",
+									"type": "minor",
+									"description": "(WIP) Aether manipulation drains the body's water supply similarly to Sand mastery."
+								}
+							]
+						},
+						{
+							"id": "ws2",
+							"title": "White Sand Volume 2",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/White_Sand_Volume 2'>White Sand Volume 2</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/White_Sand'>White Sand</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Taldain_system'>Taldain system</a>",
+							"publication": "February 2018",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/182/#e3878'>White Sand occurs prior to Elantris.</a>",
+							"sorting": {
+								"order": 2.12,
+								"publication": 2018.02,
+								"chronology": 2.2
+							},
+							"appearances": [
+								{
+									"id": "hoid",
+									"type": "appearance",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is the hooded man with a stringed instrument."
+								},
+								{
+									"id": "khriss",
+									"type": "appearance",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> is a main character."
+								}
+							],
+							"categories": [
+								"white-sand",
+								"phase2b",
+								"published",
+								"graphic"
+							],
+							"connections": [
+								{
+									"target": "mb1",
+									"type": "minor",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Trell_(Taldain)'>Trell the foreman</a> is connected to <a target='_blank' href='https://coppermind.net/wiki/Trelagism'>Trelagism</a>."
+								},
+								{
+									"target": "mb4",
+									"type": "significant",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Trell_(Taldain)'>Trell the foreman</a> is connected to the god <a target='_blank' href='https://coppermind.net/wiki/Trellism'>Trell</a>."
+								},
+								{
+									"target": "sa3",
+									"type": "egg",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Wit</a> has a jar of black sand from <a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a> in <a target='_blank' href='https://coppermind.net/wiki/Summary:Oathbringer#Chapter_67:_Mishim'>Chapter 67</a>, which turns white after <a target='_blank' href='https://coppermind.net/wiki/Shallan'>Shallan</a> <a target='_blank' href='https://coppermind.net/wiki/Lightweaving'>Lightweaves</a>."
+								},
+								{
+									"target": "sa4",
+									"type": "minor",
+									"description": "Sand from <a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a> is used to identify and quantify <a target='_blank' href='https://coppermind.net/wiki/Investiture'>kinetic Investiture</a>, including explicit mention of the fauna which makes the sand special."
+								}
+							]
+						},
+						{
+							"id": "ws3",
+							"title": "White Sand Volume 3",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/White_Sand_Volume_3'>White Sand Volume 3</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/White_Sand'>White Sand</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Taldain_system'>Taldain system</a>",
+							"publication": "October 2019",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/182/#e3878'>White Sand occurs prior to Elantris.</a>",
+							"sorting": {
+								"order": 2.13,
+								"publication": 2019.10,
+								"chronology": 2.3
+							},
+							"appearances": [
+								{
+									"id": "hoid",
+									"type": "appearance",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is the hooded man with a stringed instrument who plays a song in the <a target='_blank' href='https://coppermind.net/wiki/Summary:White_Sand_Volume_3#Epilogue'>Epilogue</a>."
+								},
+								{
+									"id": "khriss",
+									"type": "appearance",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> is a main character."
+								}
+							],
+							"categories": [
+								"white-sand",
+								"phase2b",
+								"published",
+								"graphic"
+							],
+							"connections": [
+								{
+									"target": "sa1",
+									"type": "egg",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Baon'>Baon</a> appears in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Way_of_Kings#Interlude_I-1:_Ishikk'>Interlude I-1</a> as 'Blunt'."
+								}
+							]
+						}
+					]
+				},
+				{
+					"label": "The Arcanist",
+					"children": [
+						{
+							"id": "ta1",
+							"title": "The Arcanist Volume 1",
+							"title2": "The Arcanist Volume 1",
+							"series": "The Arcanist (citation needed)",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Taldain_system'>Taldain system</a>",
+							"chronology": "Described as a sequel, so presumably occurs shortly after White Sand.",
+							"sorting": {
+								"chronology": 2.5
+							},
+							"categories": [
+								"white-sand",
+								"plan",
+								"unpublished",
+								"graphic"
+							]
+						},
+						{
+							"id": "ta2",
+							"title": "The Arcanist Volume 2",
+							"title2": "The Arcanist Volume 2",
+							"series": "The Arcanist (citation needed)",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Taldain_system'>Taldain system</a>",
+							"chronology": "Described as a sequel, so presumably occurs shortly after White Sand.",
+							"sorting": {
+								"chronology": 2.6
+							},
+							"categories": [
+								"white-sand",
+								"plan",
+								"unpublished",
+								"graphic"
+							]
+						},
+						{
+							"id": "ta3",
+							"title": "The Arcanist Volume 3",
+							"title2": "The Arcanist Volume 3",
+							"series": "The Arcanist (citation needed)",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Taldain_system'>Taldain system</a>",
+							"chronology": "Described as a sequel, so presumably occurs shortly after White Sand.",
+							"sorting": {
+								"chronology": 2.7
+							},
+							"categories": [
+								"white-sand",
+								"plan",
+								"unpublished",
+								"graphic"
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"label": "Threnody",
+			"color": "#6633cc",
+			"children": [
+				{
+					"children": [
+						{
+							"id": "sfs",
+							"title": "Shadows for Silence",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Shadows_for_Silence_in_the_Forests_of_Hell'>Shadows for Silence in the Forests of Hell</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Threnody'>Threnody</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Threnodite_system'>Threnodite system</a>",
+							"au": "Included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
+							"publication": "December 2013",
+							"chronology": "Occurs <a target='_blank' href='https://wob.coppermind.net/events/216/#e6445'>before Stormlight Archive</a> but <a target='_blank' href='https://wob.coppermind.net/events/309/#e10273'>after Warbreaker</a>.",
+							"sorting": {
+								"order": 1.5,
+								"publication": 2013.12,
+								"chronology": 6.1
+							},
+							"categories": [
+								"no-series",
+								"novella",
+								"phase1b",
+								"published"
+							],
+							"connections": [
+								{
+									"target": "sa2",
+									"type": "egg",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Mraize'>Mraize</a>'s collection in <a target='_blank' href='https://coppermind.net/wiki/Summary:Words_of_Radiance#Chapter_43:_The_Ghostbloods'>Chapter 43</a> includes a silver knife from <a target='_blank' href='https://coppermind.net/wiki/Threnody'>Threnody</a>."
+								},
+								{
+									"target": "sa3",
+									"type": "egg",
+									"description": "The silvery chain in <a target='_blank' href='https://coppermind.net/wiki/Celebrant'>Celebrant</a> is from <a target='_blank' href='https://coppermind.net/wiki/Threnody'>Threnody</a>."
+								},
+								{
+									"target": "msh",
+									"type": "minor",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Kelsier'>Kelsier</a> causes the <a target='_blank' href='https://coppermind.net/wiki/Ire'>Ire</a> to suspect <a target='_blank' href='https://coppermind.net/wiki/Shade'>Shades</a> from <a target='_blank' href='https://coppermind.net/wiki/Threnody'>Threnody</a> are nearby."
+								},
+								{
+									"target": "au",
+									"type": "minor",
+									"description": "The <a target='_blank' href='https://coppermind.net/wiki/Threnodite_system'>Threnodite system</a> essay discusses the history of <a target='_blank' href='https://coppermind.net/wiki/Threnody'>Threnody</a>."
+								},
+								{
+									"target": "sa4",
+									"type": "egg",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Raboniel'>Raboniel's</a> chain from 'the lands of the dead' is likely a <a target='_blank' href='https://coppermind.net/wiki/Silver'>silver</a> chain from <a target='_blank' href='https://coppermind.net/wiki/Threnody'>Threnody</a>."
+								}
+							]
+						}
+					]
+				},
+				{
+					"children": [
+						{
+							"id": "db",
+							"title": "The Dust Brigade",
+							"title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=the+dust+brigade'>The Dust Brigade</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Threnody'>Threnody</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Threnodite_system'>Threnodite system</a>",
+							"categories": [
+								"no-series",
+								"plan",
+								"unpublished",
+								"novel"
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"label": "First of<br>the Sun",
+			"color": "#367485",
+			"children": [
+				{
+					"children": [
+						{
+							"id": "sotd",
+							"title": "Sixth of the Dusk",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Sixth_of_the_Dusk'>Sixth of the Dusk</a>",
+							"series": "Sixth of<br>the Dusk",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/First_of_the_Sun'>First of the Sun</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Drominad_system'>Drominad system</a>",
+							"au": "Included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
+							"publication": "June 2014",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/60/#e6664'>Shortly before Mistborn Era 4.</a>",
+							"sorting": {
+								"order": 1.6,
+								"publication": 2014.06,
+								"chronology": 13.0
+							},
+							"categories": [
+								"no-series",
+								"novella",
+								"phase1b",
+								"published"
+							],
+							"connections": [
+								{
+									"target": "sa3",
+									"type": "minor",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Mraize'>Mraize</a>'s chicken, mentioned in <a target='_blank' href='https://coppermind.net/wiki/Summary:Oathbringer#Chapter_22:_The_Darkness_Within'>Chapter 22</a>, is an <a target='_blank' href='https://coppermind.net/wiki/Aviar'>Aviar</a>. <a target='_blank' href='https://coppermind.net/wiki/Patji'>Patji</a> is referenced obliquely in <a target='_blank' href='https://coppermind.net/wiki/Autonomy'>Autonomy</a>'s <a target='_blank' href='https://coppermind.net/wiki/Letters#Second_Oathbringer_Letter'>letter</a> to <a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> in the <a target='_blank' href='https://coppermind.net/wiki/Oathbringer/Epigraphs#Letters'>Part 2 epigraphs</a>."
+								},
+								{
+									"target": "au",
+									"type": "minor",
+									"description": "The <a target='_blank' href='https://coppermind.net/wiki/Drominad_system'>Drominad system</a> essay discusses <a target='_blank' href='https://coppermind.net/wiki/First_of_the_Sun'>First of the Sun</a> and its magic."
+								},
+								{
+									"target": "sa4",
+									"type": "minor",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Gereh'>Gereh</a> has an <a target='_blank' href='https://coppermind.net/wiki/Aviar'>Aviar</a>, which <a target='_blank' href='https://coppermind.net/wiki/Lift'>Lift</a> comes into possession of."
+								}
+							]
+						},
+						{
+							"id": "sotd2",
+							"title": "Sixth of the Dusk sequel",
+							"title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=sixth+of+the+dusk+sequel'>Sixth of the Dusk sequel</a>",
+							"series": "Sixth of<br>the Dusk",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/First_of_the_Sun'>First of the Sun</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Drominad_system'>Drominad system</a>",
+							"chronology": "Five years after Sixth of the Dusk.",
+							"sorting": {
+								"chronology": 13.02
+							},
+							"link": "<a target='_blank' href='https://wob.coppermind.net/events/448/#e14408'>Excerpt on Arcanum.</a> (some may consider to be spoilers)",
+							"categories": [
+								"no-series",
+								"novella",
+								"plan",
+								"unpublished"
+							]
+						}
+					]
+				},
+				{
+					"children": [
+						{
+							"id": "kingmaker",
+							"title": "Kingmaker",
+							"title2": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>Kingmaker</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/First_of_the_Sun'>First of the Sun</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Drominad_system'>Drominad system</a>",
+							"link": "<a target='_blank' href='https://wob.coppermind.net/events/479/#e15153'>Reading on Arcanum.</a>",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/479/#e15153'>The reading suggests a setting not long after Sixth of the Dusk.</a>",
+							"sorting": {
+								"chronology": 13.01
+							},
+							"categories": [
+								"no-series",
+								"novel",
+								"plan",
+								"unpublished"
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"label": "Yolen",
+			"color": "#d98a41",
+			"children": [
+				{
+					"label": "Dragonsteel",
+					"children": [
+						{
+							"id": "d1",
+							"title": "Dragonsteel 1",
+							"title2": "Dragonsteel 1",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/Dragonsteel'>Dragonsteel</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Yolen'>Yolen</a>",
+							"system": "Yolish system",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/103/#e1024'>Dragonsteel is the first series in the cosmere storyline.</a>",
+							"sorting": {
+								"chronology": 1.1
+							},
+							"categories": [
+								"dragonsteel",
+								"plan",
+								"unpublished",
+								"novel"
+							],
+							"connections": [
+								{
+									"target": "mb7",
+									"type": "egg",
+									"description": "(WIP) A Sho Del is described in the epilogue."
+								}
+							]
+						},
+						{
+							"id": "d2",
+							"title": "Dragonsteel 2",
+							"title2": "Dragonsteel 2",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/Dragonsteel'>Dragonsteel</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Yolen'>Yolen</a>",
+							"system": "Yolish system",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/103/#e1024'>Dragonsteel is the first series in the cosmere storyline.</a>",
+							"sorting": {
+								"chronology": 1.2
+							},
+							"categories": [
+								"dragonsteel",
+								"plan",
+								"unpublished",
+								"novel"
+							]
+						},
+						{
+							"id": "d3",
+							"title": "Dragonsteel 3",
+							"title2": "Dragonsteel 3",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/Dragonsteel'>Dragonsteel</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Yolen'>Yolen</a>",
+							"system": "Yolish system",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/103/#e1024'>Dragonsteel is the first series in the cosmere storyline.</a>",
+							"sorting": {
+								"chronology": 1.3
+							},
+							"categories": [
+								"dragonsteel",
+								"plan",
+								"unpublished",
+								"novel"
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"label": "Other",
+			"color": "#a0a0a0",
+			"children": [
+				{
+					"label": "Aether<br>Series",
+					"color": "#e3a1e3",
+					"children": [
+						{
+							"id": "aether1",
+							"title": "Aether Book 1",
+							"title2": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2019/'>Aether Book 1</a>",
+							"world": "Unknown",
+							"system": "Unknown",
+							"categories": [
+								"aether",
+								"novel",
+								"plan",
+								"unpublished"
+							]
+						},
+						{
+							"id": "aether2",
+							"title": "Aether Book 2",
+							"title2": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2019/'>Aether Book 2</a>",
+							"world": "Unknown",
+							"system": "Unknown",
+							"categories": [
+								"aether",
+								"novel",
+								"plan",
+								"unpublished"
+							]
+						},
+						{
+							"id": "aether3",
+							"title": "Aether Book 3",
+							"title2": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2019/'>Aether Book 3</a>",
+							"world": "Unknown",
+							"system": "Unknown",
+							"categories": [
+								"aether",
+								"novel",
+								"plan",
+								"unpublished"
+							]
+						}
+					]
+				},
+				{
+					"children": [
+						{
+							"id": "secret1",
+							"title": "Secret Project 1 (2023)",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Secret_Project_One'>Secret Project 1</a>",
+							"world": "Spoiler",
+							"system": "Spoiler",
+							"publication": "January 2023",
+							"sorting": {
+								"publication": 2023.01
+							},
+							"link": "Chapters 1-5 available on <a target='_blank' href='brandonsanderson.com/first-look-at-secret-project-1'>Brandon's website</a> and <a target='_blank' href='https://youtu.be/bBUVXcIE0E0'>YouTube</a>. (some may consider to be spoilers)",
+							"categories": [
+								"no-series",
+								"novel",
+								"plan",
+								"forthcoming"
+							]
+						}
+					]
+				},
+				{
+					"children": [
+						{
+							"id": "secret3",
+							"title": "Secret Project 3 (2023)",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Secret_Project_Three'>Secret Project 3</a>",
+							"world": "Spoiler",
+							"system": "Spoiler",
+							"publication": "July 2023",
+							"sorting": {
+								"publication": 2023.07
+							},
+							"link": "Chapters 1-7 available on <a target='_blank' href='brandonsanderson.com/first-look-at-secret-project-3'>Brandon's website</a> and <a target='_blank' href='https://youtu.be/cFGDcvtRdz0'>YouTube</a>. (some may consider to be spoilers)",
+							"categories": [
+								"no-series",
+								"novel",
+								"plan",
+								"forthcoming"
+							]
+						}
+					]
+				},
+				{
+					"children": [
+						{
+							"id": "secret4",
+							"title": "Secret Project 4 (2023)",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Secret_Project_Four'>Secret Project 4</a>",
+							"world": "Spoiler",
+							"system": "Spoiler",
+							"publication": "October 2023",
+							"sorting": {
+								"publication": 2023.10
+							},
+							"categories": [
+								"no-series",
+								"novel",
+								"plan",
+								"forthcoming"
+							]
+						}
+					]
+				},
+				{
+					"children": [
+						{
+							"id": "silverlight",
+							"title": "Silverlight novella",
+							"title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=silverlight+novella'>Silverlight novella</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Cognitive_Realm'>Cognitive Realm</a>",
+							"system": "N/A",
+							"categories": [
+								"no-series",
+								"novella",
+								"plan",
+								"unpublished"
+							]
+						}
+					]
+				},
+				{
+					"children": [
+						{
+							"id": "kite",
+							"title": "Magic Kites YA story",
+							"title2": "<a target='_blank' href='https://wob.coppermind.net/adv_search/?tags=kite+magic'>Kite-based magic story</a>",
+							"world": "Unknown",
+							"system": "Unknown",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/379/#e12466'>Planned to take place between Mistborn Era 3 and 4.</a>",
+							"sorting": {
+								"chronology": 11.0
+							},
+							"categories": [
+								"no-series",
+								"novella",
+								"plan",
+								"unpublished"
+							]
+						}
+					]
+				},
+				{
+					"children": [
+						{
+							"id": "au",
+							"title": "Arcanum Unbounded (essays)",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded (essays)</a>",
+							"world": "N/A",
+							"system": "N/A",
+							"au": "Included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded</a>.",
+							"publication": "November 2016",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/36/#e1491'>The essays were written before the events of Sixth of the Dusk.</a> They could potentially be as early as Mistborn Era 3.",
+							"sorting": {
+								"order": 2.3,
+								"publication": 2016.11,
+								"chronology": 12.0
+							},
+							"appearances": [
+								{
+									"id": "khriss",
+									"type": "mention",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> is the author of the essays."
+								}
+							],
+							"categories": [
+								"no-series",
+								"short",
+								"phase2",
+								"published"
+							],
+							"connections": [
+								{
+									"target": "sa4",
+									"type": "minor",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Devotion'>Devotion</a> and <a target='_blank' href='https://coppermind.net/wiki/Dominion'>Dominion</a> are referenced in the <a target='_blank' href='https://coppermind.net/wiki/Rhythm_of_War/Epigraphs'>Chapter 26 Epigraph</a>. <a target='_blank' href='https://coppermind.net/wiki/Ambition'>Ambition's</a> struggle with <a target='_blank' href='https://coppermind.net/wiki/Odium'>Odium</a> is referenced in the <a target='_blank' href='https://coppermind.net/wiki/Rhythm_of_War/Epigraphs'>Chapter 27 Epigraph</a>."
+								},
+								{
+									"target": "mb7",
+									"type": "minor",
+									"description": "(WIP) Moonlight references the death of Devotion and Dominion in chapter 40. Autonomy's original planet is revealed in The Taldain System Essay."
+								}
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"label": "Mixed",
+			"color": "#a0a0a0",
+			"children": [
+				{
+					"children": [
+						{
+							"id": "wsp",
+							"title": "White Sand (prose)",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/White_Sand_(prose)'>White Sand (prose)</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Taldain'>Taldain</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Taldain_system'>Taldain system</a>",
+							"au": "Excerpt included in <a target='_blank' href='https://coppermind.net/wiki/Arcanum_Unbounded'>Arcanum Unbounded.</a>.",
+							"link": "<a target='_blank' href='https://brandonsanderson.com/newsletter-signup/'>Link to full text found in Brandon's newsletter.</a>",
+							"publication": "June 2009 (upon request)",
+							"chronology": "<a target='_blank' href='https://wob.coppermind.net/events/182/#e3878'>White Sand occurs prior to Elantris.</a>",
+							"sorting": {
+								"order": 2.14,
+								"publication": 2009.06,
+								"chronology": 2.0
+							},
+							"appearances": [
+								{
+									"id": "khriss",
+									"type": "appearance",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Khrissalla'>Khriss</a> is a main character."
+								}
+							],
+							"categories": [
+								"white-sand",
+								"novel",
+								"apocryphal",
+								"noncanon"
+							],
+							"connections": [
+								{
+									"target": "ws1",
+									"type": "minor",
+									"description": "The <a target='_blank' href='https://coppermind.net/wiki/White_Sand'>White Sand</a> graphic novels are based on the prose version."
+								}
+							]
+						},
+						{
+							"id": "aon",
+							"title": "Aether of Night",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Aether_of_Night'>Aether of Night</a>",
+							"world": "Unknown",
+							"system": "Unknown",
+							"link": "<a target='_blank' href='https://www.17thshard.com/forum/topic/60219-aether-of-night-manuscript-requests/'>Full text available from the 17th Shard.</a>",
+							"publication": "June 2009 (upon request)",
+							"sorting": {
+								"order": 2.92,
+								"publication": 2009.06
+							},
+							"categories": [
+								"no-series",
+								"apocryphal",
+								"noncanon",
+								"novel"
+							],
+							"connections": [
+								{
+									"target": "sa2",
+									"type": "egg",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Mraize'>Mraize</a>'s collection in <a target='_blank' href='https://coppermind.net/wiki/Summary:Words_of_Radiance#Chapter_43:_The_Ghostbloods'>Chapter 43</a> includes pink <a target='_blank' href='https://coppermind.net/wiki/Aether'>aether</a>."
+								},
+								{
+									"target": "sa3",
+									"type": "egg",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Mraize'>Mraize</a> mentions his suit was stained with <a target='_blank' href='https://coppermind.net/wiki/Aether'>aether</a>."
+								},
+								{
+									"target": "sa4",
+									"type": "egg",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Foil'>Foil</a> is said to be seeking 'control over the <a target='_blank' href='https://coppermind.net/wiki/Aether'>aethers</a>'."
+								},
+								{
+									"target": "mb7",
+									"type": "minor",
+									"description": "(WIP) TwinSoul can manipulates the Aethers."
+								}
+							]
+						},
+						{
+							"id": "imperial-fool",
+							"title": "Imperial Fool",
+							"title2": "Imperial Fool",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Sel'>Sel</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Selish_system'>Selish system</a>",
+							"link": "<a target='_blank' href='https://brandonsanderson.com/the-emperors-soul-deleted-prologue-imperial-fool'>Full text on Brandon's website.</a>",
+							"publication": "November 2012",
+							"chronology": "Concerns events shortly before the events of The Emperor's Soul.",
+							"sorting": {
+								"order": 1.41,
+								"publication": 2012.11,
+								"chronology": 3.4
+							},
+							"appearances": [
+								{
+									"id": "hoid",
+									"type": "appearance",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is the 'Imperial Fool'."
+								}
+							],
+							"categories": [
+								"no-series",
+								"short",
+								"apocryphal",
+								"noncanon"
+							]
+						},
+						{
+							"id": "twokp",
+							"title": "The Way of Kings Prime",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Way_of_Kings_Prime'>The Way of Kings Prime</a>",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+							"link": "<a target='_blank' href='https://www.brandonsanderson.com/the-way-of-kings-prime/'>Full novel on Brandon's website.</a>",
+							"publication": "July 2020",
+							"sorting": {
+								"order": 2.91,
+								"publication": 2020.07
+							},
+							"categories": [
+								"stormlight",
+								"novel",
+								"apocryphal",
+								"noncanon"
+							]
+						},
+						{
+							"id": "jasnah",
+							"title": "Jasnah deleted scene",
+							"title2": "Jasnah deleted scene",
+							"series": "<a target='_blank' href='https://coppermind.net/wiki/The_Stormlight_Archive'>Stormlight Archive</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Roshar'>Roshar</a>",
+							"system": "<a target='_blank' href='https://coppermind.net/wiki/Rosharan_system'>Rosharan system</a>",
+							"link": "<a target='_blank' href='https://www.tor.com/2014/08/06/stormlight-archive-scene-after-words-of-radiance'>Full text on Tor.com.</a>",
+							"publication": "August 2014",
+							"chronology": "Occurs during the early events of Words of Radiance.",
+							"sorting": {
+								"order": 2.421,
+								"publication": 2014.08,
+								"chronology": 7.021
+							},
+							"categories": [
+								"stormlight",
+								"short",
+								"apocryphal",
+								"noncanon"
+							]
+						},
+						{
+							"id": "traveler",
+							"title": "The Traveler",
+							"title2": "The Traveler",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Yolen'>Yolen</a>",
+							"system": "Yolish system",
+							"link": "<a target='_blank' href='https://wob.coppermind.net/events/332/#e9518'>Full text on Arcanum.</a>",
+							"publication": "April 2018",
+							"chronology": "Occurs shortly after Mistborn Era 1.",
+							"sorting": {
+								"order": 2.26,
+								"publication": 2018.04,
+								"chronology": 4.5
+							},
+							"appearances": [
+								{
+									"id": "hoid",
+									"type": "appearance",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Hoid'>Hoid</a> is 'the Traveler'."
+								}
+							],
+							"categories": [
+								"no-series",
+								"short",
+								"apocryphal",
+								"noncanon"
+							]
+						}
+					]
+				}
+			]
+		}
+	]
 }

--- a/public/data.json
+++ b/public/data.json
@@ -792,14 +792,15 @@
 						},
 						{
 							"id": "mb7",
-							"title": "The Lost Metal (2022)",
+							"title": "The Lost Metal",
 							"title2": "<a target='_blank' href='https://coppermind.net/wiki/The_Lost_Metal'>The Lost Metal</a>",
 							"series": "<a target='_blank' href='https://coppermind.net/wiki/Mistborn_(series)'>Mistborn</a> (Era 2)",
 							"world": "<a target='_blank' href='https://coppermind.net/wiki/Scadrial'>Scadrial</a>",
 							"system": "<a target='_blank' href='https://coppermind.net/wiki/Scadrian_system'>Scadrian system</a>",
-							"publication": "<a target='_blank' href='https://www.brandonsanderson.com/state-of-the-sanderson-2020/'>Fall 2022</a>",
+							"publication": "Fall 2022",
 							"chronology": "Mistborn Era 2 occurs <a target='_blank' href='https://wob.coppermind.net/events/260/#e8747'>after Stormlight Archive book 5</a> and <a target='_blank' href='https://wob.coppermind.net/events/454-dragonmount-zoom-call/#e14582'>before Stormlight Archive book 6</a>.",
 							"sorting": {
+								"order": 2.27
 								"publication": 2022.11,
 								"chronology": 8.4
 							},
@@ -1267,7 +1268,7 @@
 								{
 									"target": "mb7",
 									"type": "egg",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Wayne'>Wayne</a> buys some <a target='_blank' href='https://coppermind.net/wiki/Chouta'>chouta</a> from a street vendor in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Lost_Metal#Chapter_32'>Chapter 32</a>. <a target='_blank' href='https://coppermind.net/wiki/Dlavil'>Dlavil</a> is <a target='_blank' href='https://coppermind.net/wiki/Iyatil'>Iyatil</a>'s Brother"
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Wayne'>Wayne</a> buys some <a target='_blank' href='https://coppermind.net/wiki/Chouta'>chouta</a> from a street vendor in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Lost_Metal#Chapter_32'>Chapter 32</a>. <a target='_blank' href='https://coppermind.net/wiki/Dlavil'>Dlavil</a> is <a target='_blank' href='https://coppermind.net/wiki/Iyatil'>Iyatil</a>'s brother"
 								}
 							]
 						},
@@ -1405,9 +1406,9 @@
 							],
 							"connections": [
 								{
-									"target": "d1",
+									"target": "dsp",
 									"type": "egg",
-									"description": "<a target='_blank' href='https://coppermind.net/wiki/Microkinesis'>Microkinesis</a> referes to a type of magic from <a target='_blank' href='https://coppermind.net/wiki/Yolen'>Yolen</a> in <a target='_blank' href='https://coppermind.net/wiki/Dragonsteel'>Dragonsteel</a>."
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Microkinesis'>Microkinesis</a> referes to a type of magic from <a target='_blank' href='https://coppermind.net/wiki/Yolen'>Yolen</a> in <a target='_blank' href='https://coppermind.net/wiki/Dragonsteel Prime'>Dragonsteel Prime</a>."
 								},
 								{
 									"target": "mb2",
@@ -2419,6 +2420,31 @@
 								"short",
 								"apocryphal",
 								"noncanon"
+							]
+						},
+						{
+							"id": "dsp",
+							"title": "Dragonsteel Prime",
+							"title2": "<a target='_blank' href='https://coppermind.net/wiki/Dragonsteel_Prime'>Dragonsteel Prime</a>",
+							"world": "<a target='_blank' href='https://coppermind.net/wiki/Yolen'>Yolen</a>",
+							"system": "Yolish system",
+							"publication": "<a target='_blank' href='https://wob.coppermind.net/events/488/#e15395'>Fall 2023</a>",
+							"sorting": {
+								"order": 2.90,
+								"publication": 2023.09
+							},
+							"categories": [
+								"dragonsteel",
+								"novel",
+								"apocryphal",
+								"noncanon"
+							],
+							"connections": [
+								{
+									"target": "mb7",
+									"type": "egg",
+									"description": "<a target='_blank' href='https://coppermind.net/wiki/Jan_Ven'>Jan Ven</a>, mentioned in the <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Lost_Metal#Epilogue_6'>6th Epilogue</a>, is a <a target='_blank' href='https://coppermind.net/wiki/Sho_Del'>Sho Del</a>–a species of beings first mentioned in Dragonsteel."
+								}
 							]
 						},
 						{

--- a/public/data.json
+++ b/public/data.json
@@ -828,9 +828,14 @@
 							],
 							"connections": [
 								{
-									"target": "mb7",
+									"target": "msh",
 									"type": "egg",
 									"description": "The glowing jars the <a target='_blank' href='https://coppermind.net/wiki/Ire'>Ire</a> are using might be purified <a target='_blank' href='https://coppermind.net/wiki/Dor'>Dor</a>."
+								},
+								{
+									"target": "sa1",
+									"type": "egg",
+									"description": "The 'people with golden hair living on the east side', mentioned by <a target='_blank' href='https://coppermind.net/wiki/Maraga_Dulcet'>Maraga</a> in <a target='_blank' href='https://coppermind.net/wiki/Summary:The_Lost_Metal#Chapter_32'>Chapter 32</a>, are probably <a target='_blank' href='https://coppermind.net/wiki/Iriali'>Iriali</a>."
 								}
 							]
 						},


### PR DESCRIPTION
- I only touched the data.json file
- I did accidently auto-reformat it, didn't change much, but it did add a space before each line (sorry about that, noticed too late) 
\>\>\>**I suggest hiding whitespace changes to see my actual changes clearly**<<<

- The Ghostbloods connection is still missing, awaiting some further consideration on how to write it/which Stormlight book to connect it
- A possible link to White Sand is missing, If there's need of one
- There's a bunch more links we could put in, but those are theories that would need WoB confirmation
- Jofwu helped me out for the descriptions
- I think it's ready to go up on the site, adjustments can be made afterward 